### PR TITLE
Widget CloudKit fetch

### DIFF
--- a/Tickmate/Tickmate.xcodeproj/project.pbxproj
+++ b/Tickmate/Tickmate.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		59342E1C2603F3DF007E9F64 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59342E1B2603F3DF007E9F64 /* OnboardingView.swift */; };
 		5939239C2654CE050085DABD /* PageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5939239B2654CE050085DABD /* PageView.swift */; };
 		5939239E2655B6C90085DABD /* Animation+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5939239D2655B6C90085DABD /* Animation+Push.swift */; };
+		5956ACC4268EA0DA0005B5CC /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5964545125E987C9004FE184 /* CloudKit.framework */; };
+		5956ACC5268EA3440005B5CC /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5964545125E987C9004FE184 /* CloudKit.framework */; };
 		59603D452666C85A001482C6 /* StoreController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59603D442666C85A001482C6 /* StoreController.swift */; };
 		5964545225E987C9004FE184 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5964545125E987C9004FE184 /* CloudKit.framework */; };
 		597A7FDD25F6E1C900256268 /* StateEditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597A7FDC25F6E1C900256268 /* StateEditButton.swift */; };
@@ -190,6 +192,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5901D4CF2684281A00A5BE86 /* SwiftUI.framework in Frameworks */,
+				5956ACC4268EA0DA0005B5CC /* CloudKit.framework in Frameworks */,
 				5901D4CD2684281A00A5BE86 /* WidgetKit.framework in Frameworks */,
 				5931643B2685409F005DDA1A /* SwiftDate in Frameworks */,
 			);
@@ -199,6 +202,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5956ACC5268EA3440005B5CC /* CloudKit.framework in Frameworks */,
 				5931646126857AA9005DDA1A /* SwiftDate in Frameworks */,
 				5931644726857779005DDA1A /* Intents.framework in Frameworks */,
 			);

--- a/Tickmate/Tickmate/Controllers/GroupController.swift
+++ b/Tickmate/Tickmate/Controllers/GroupController.swift
@@ -61,6 +61,6 @@ extension GroupController: NSFetchedResultsControllerDelegate {
         if changed {
             trackController?.scheduleSave()
         }
-        trackController?.scheduleSave(now: true)
+        trackController?.saveIfScheduled()
     }
 }

--- a/Tickmate/Tickmate/Controllers/Persistence.swift
+++ b/Tickmate/Tickmate/Controllers/Persistence.swift
@@ -179,7 +179,7 @@ class PersistenceController {
         } else {
             container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
             
-            let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.vc.isv.Tickmate")!.appendingPathComponent("Tickmate.sqlite")
+            let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupID)!.appendingPathComponent("Tickmate.sqlite")
             
             let oldURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.appendingPathComponent("Tickmate.sqlite")
             UserDefaults.standard.register(defaults: [Defaults.appGroupDatabaseMigration.rawValue: false])

--- a/Tickmate/Tickmate/Controllers/Persistence.swift
+++ b/Tickmate/Tickmate/Controllers/Persistence.swift
@@ -23,7 +23,7 @@ class PersistenceController {
         result.previewGroup = group
         
         let dateString = TrackController.iso8601.string(from: Date() - 5.days)
-        for i: Int16 in 0..<3 {
+        for i: Int16 in 0..<5 {
             let track = Track(
                 name: String(UUID().uuidString.dropLast(28)),
                 multiple: i > 0,

--- a/Tickmate/Tickmate/Controllers/Persistence.swift
+++ b/Tickmate/Tickmate/Controllers/Persistence.swift
@@ -180,7 +180,6 @@ class PersistenceController {
             container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
             
             let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.vc.isv.Tickmate")!.appendingPathComponent("Tickmate.sqlite")
-            let appGroupDescription = NSPersistentStoreDescription(url: appGroupURL)
             
             let oldURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.appendingPathComponent("Tickmate.sqlite")
             UserDefaults.standard.register(defaults: [Defaults.appGroupDatabaseMigration.rawValue: false])
@@ -195,7 +194,7 @@ class PersistenceController {
             
             // Load the current persistent store
             if !needsMigration {
-                container.persistentStoreDescriptions = [appGroupDescription]
+                container.persistentStoreDescriptions.first?.url = appGroupURL
             }
             
             container.loadPersistentStores { storeDescription, error in

--- a/Tickmate/Tickmate/Controllers/TickController.swift
+++ b/Tickmate/Tickmate/Controllers/TickController.swift
@@ -56,9 +56,6 @@ class TickController: NSObject, ObservableObject {
         }
         
         loadTicks()
-        if !observeChanges {
-            loadCKTicks()
-        }
     }
     
     func setTodayOffset() -> Int? {

--- a/Tickmate/Tickmate/Controllers/TickController.swift
+++ b/Tickmate/Tickmate/Controllers/TickController.swift
@@ -15,17 +15,19 @@ class TickController: NSObject, ObservableObject {
     let track: Track
     @Published var ticks: [Tick?] = []
     /// The tick count for a given day as fetche with `loadCKTicks` for new days that aren't already in `ticks`.
-    @Published var ckTicks: [Int: Int] = [:]
+    @Published var ckTicks: [Int16?]?
     private var fetchedResultsController: NSFetchedResultsController<Tick>
     weak var trackController: TrackController?
     var todayOffset: Int?
     
     private var preview: Bool
+    private var observeChanges: Bool
     
     init(track: Track, trackController: TrackController, observeChanges: Bool = true, preview: Bool) {
         self.track = track
         self.trackController = trackController
         self.preview = preview
+        self.observeChanges = observeChanges
         
         let moc = track.managedObjectContext ?? (preview ? PersistenceController.preview : PersistenceController.shared).container.viewContext
         
@@ -53,20 +55,28 @@ class TickController: NSObject, ObservableObject {
             NSLog("Error performing Ticks fetch for \(track.name ?? "track"): \(error)")
         }
         
-        loadTicks()
+        if observeChanges {
+            loadTicks()
+        } else {
+            loadCKTicks()
+        }
     }
     
-    func loadTicks() {
-        guard let allTicks = fetchedResultsController.fetchedObjects,
-              // Calculate today's offset
-              let startDateString = track.startDate,
+    func setTodayOffset() -> Int? {
+        guard let startDateString = track.startDate,
               let startDate = DateInRegion(startDateString, region: .current)?.dateTruncated(at: [.hour, .minute, .second]),
               let today = trackController?.date.in(region: .current).dateTruncated(at: [.hour, .minute, .second]),
               // Subtract 2 hours here to overestimate the offset to account for for any daylight savings time changes.
               // Because we're truncating at the number of days, having one or two hours extra won't increase
               // the day offset, but having one hour less because of DST would incorrectly offset the day.
-              let todayOffset = (today - (startDate - 2.hours)).toUnit(.day) else { return }
+              let todayOffset = (today - (startDate - 2.hours)).toUnit(.day) else { return nil }
         self.todayOffset = todayOffset
+        return todayOffset
+    }
+    
+    func loadTicks() {
+        guard let allTicks = fetchedResultsController.fetchedObjects,
+              let todayOffset = setTodayOffset() else { return }
         
         var ticks = [Tick?]()
         var i = 0
@@ -114,37 +124,39 @@ class TickController: NSObject, ObservableObject {
         }
         
         self.ticks = ticks
-        if track.name == "Washed water bottle" {
-            loadCKTicks { }
-        }
     }
     
     /// Fetch `CKRecord`s for the `Tick`s for this `Track` and save them to `ckTicks`.
     ///
-    /// Enters the tick count for each day into `ckTicks` that doesn't already have a `Tick` in `ticks`.
-    /// For fetching updates while the app runs in the background or in an extension, like the widget extensien.
+    /// Enters the tick count for each day into `ckTicks`.
+    /// Only works when `observeChanges` is `false`, such as
+    /// while the app runs in the background or in an extension, like the widget extension.
     /// - Parameter completion: runs on the main thread after the fetched ticks have been assigned to `ckTicks`.
-    func loadCKTicks(completion: @escaping () -> Void) {
+    func loadCKTicks(completion: @escaping () -> Void = {}) {
+        print("loadCKTicks", track.name ?? "")
         let container = (preview ? PersistenceController.preview : PersistenceController.shared).container
         guard let trackID = container.recordID(for: track.objectID)?.recordName,
-              let todayOffset = todayOffset else { return }
+              let todayOffset = setTodayOffset(),
+              // Don't load CloudKit Ticks unless fetching for an app extension
+              !observeChanges else { return completion() }
         
         let predicate = NSPredicate(format: "CD_track == %@", trackID)
         let query = CKQuery(recordType: "CD_Tick", predicate: predicate)
+        
         let operation = CKQueryOperation(query: query)
         operation.desiredKeys = ["CD_dayOffset", "CD_count"]
         
-        let ticks = self.ticks
-        var ckTicks = [Int: Int]()
+        var ckTicks = [Int16?]()
         
         operation.recordFetchedBlock = { record in
-            guard let dayOffset = (record["CD_dayOffset"] as? NSNumber)?.intValue,
-                  todayOffset - dayOffset < 365 else { return }
+            guard let dayOffset = (record["CD_dayOffset"] as? NSNumber)?.intValue else { return }
             let day = todayOffset - dayOffset
+            guard day >= 0 && day < 365 else { return }
             
-            if ticks[day] == nil {
-                ckTicks[day] = (record["CD_count"] as? NSNumber)?.intValue ?? 1
+            while ckTicks.count <= day {
+                ckTicks.append(nil)
             }
+            ckTicks[day] = (record["CD_count"] as? NSNumber)?.int16Value ?? 1
         }
         
         operation.queryCompletionBlock = { [weak self] _, error in
@@ -153,16 +165,26 @@ class TickController: NSObject, ObservableObject {
             }
             DispatchQueue.main.async {
                 self?.ckTicks = ckTicks
-                print(ckTicks)
-                print("Done fetching CloudKit Ticks for", self?.track.name ?? "track")
+                print("Done fetching CloudKit Ticks for", self?.track.name ?? "track", ckTicks)
                 completion()
             }
         }
         
-        CKContainer.default().privateCloudDatabase.add(operation)
+        // The identifier needs to be specified for when this runs in an app extension.
+        CKContainer(identifier: "iCloud.vc.isv.Tickmate").privateCloudDatabase.add(operation)
     }
     
     //MARK: Ticking
+    
+    func tickCount(for day: Int) -> Int16 {
+        // If CloudKit Ticks have been loaded, show those
+        if let ckTicks = ckTicks {
+            guard ckTicks.indices.contains(day) else { return 0 }
+            return ckTicks[day] ?? 0
+        }
+        
+        return getTick(for: day)?.count ?? 0
+    }
     
     func getTick(for day: Int) -> Tick? {
         guard ticks.indices.contains(day) else { return nil }

--- a/Tickmate/Tickmate/Controllers/TickController.swift
+++ b/Tickmate/Tickmate/Controllers/TickController.swift
@@ -55,9 +55,8 @@ class TickController: NSObject, ObservableObject {
             NSLog("Error performing Ticks fetch for \(track.name ?? "track"): \(error)")
         }
         
-        if observeChanges {
-            loadTicks()
-        } else {
+        loadTicks()
+        if !observeChanges {
             loadCKTicks()
         }
     }
@@ -287,5 +286,10 @@ extension TickController: NSFetchedResultsControllerDelegate {
         default:
             break
         }
+        
+        // This is done here as opposed to in the tick(day:)
+        // function so that the timeline will alse be
+        // refreshed on changes fetched from CloudKit.
+        trackController?.scheduleTimelineRefresh()
     }
 }

--- a/Tickmate/Tickmate/Controllers/TickController.swift
+++ b/Tickmate/Tickmate/Controllers/TickController.swift
@@ -142,9 +142,11 @@ class TickController: NSObject, ObservableObject {
         
         let predicate = NSPredicate(format: "CD_track == %@", trackID)
         let query = CKQuery(recordType: "CD_Tick", predicate: predicate)
+        query.sortDescriptors = [NSSortDescriptor(key: "CD_dayOffset", ascending: false)]
         
         let operation = CKQueryOperation(query: query)
         operation.desiredKeys = ["CD_dayOffset", "CD_count"]
+        operation.resultsLimit = 20
         
         var ckTicks = [Int16?]()
         

--- a/Tickmate/Tickmate/Controllers/TrackController.swift
+++ b/Tickmate/Tickmate/Controllers/TrackController.swift
@@ -63,22 +63,26 @@ class TrackController: NSObject, ObservableObject {
             Defaults.relativeDates.rawValue: true
         ])
         
+        TrackController.migrateUserDefaultsIfNeeded()
+        
+        UserDefaults(suiteName: groupID)?.register(defaults: [
+            Defaults.weekStartDay.rawValue: 2
+        ])
+        
         date = Date() - TrackController.dayOffset
         weekday = date.in(region: .current).weekday
         
-        weekStartDay = UserDefaults.standard.integer(forKey: Defaults.weekStartDay.rawValue)
+        weekStartDay = UserDefaults(suiteName: groupID)?.integer(forKey: Defaults.weekStartDay.rawValue) ?? 2
         relativeDates = UserDefaults.standard.bool(forKey: Defaults.relativeDates.rawValue)
         
         super.init()
-        
-        migrateUserDefaultsIfNeeded()
     }
     
     static var dayOffset: DateComponents {
         (UserDefaults.standard.bool(forKey: Defaults.customDayStart.rawValue) ? UserDefaults.standard.integer(forKey: Defaults.customDayStartMinutes.rawValue) : 0).minutes
     }
     
-    private func migrateUserDefaultsIfNeeded() {
+    private static func migrateUserDefaultsIfNeeded() {
         if let userDefaults = UserDefaults(suiteName: groupID),
            !userDefaults.bool(forKey: Defaults.userDefaultsMigration.rawValue) {
             let customDayStart = Defaults.customDayStart.rawValue
@@ -223,9 +227,9 @@ class TrackController: NSObject, ObservableObject {
     
     func setCustomDayStart(minutes givenMinutes: Int) {
         let minutes: Int
-        if UserDefaults.standard.bool(forKey: Defaults.customDayStart.rawValue) {
+        if UserDefaults(suiteName: groupID)?.bool(forKey: Defaults.customDayStart.rawValue) ?? false {
             minutes = givenMinutes
-            UserDefaults.standard.setValue(minutes, forKey: Defaults.customDayStartMinutes.rawValue)
+            UserDefaults(suiteName: groupID)?.setValue(minutes, forKey: Defaults.customDayStartMinutes.rawValue)
         } else {
             // Clear the offset if customDayStart is off
             minutes = 0

--- a/Tickmate/Tickmate/Controllers/TrackController.swift
+++ b/Tickmate/Tickmate/Controllers/TrackController.swift
@@ -59,7 +59,6 @@ class TrackController: NSObject, ObservableObject {
         self.preview = preview
         
         UserDefaults.standard.register(defaults: [
-            Defaults.customDayStartMinutes.rawValue: 0,
             Defaults.weekStartDay.rawValue: 2,
             Defaults.relativeDates.rawValue: true
         ])
@@ -71,10 +70,29 @@ class TrackController: NSObject, ObservableObject {
         relativeDates = UserDefaults.standard.bool(forKey: Defaults.relativeDates.rawValue)
         
         super.init()
+        
+        migrateUserDefaultsIfNeeded()
     }
     
     static var dayOffset: DateComponents {
         (UserDefaults.standard.bool(forKey: Defaults.customDayStart.rawValue) ? UserDefaults.standard.integer(forKey: Defaults.customDayStartMinutes.rawValue) : 0).minutes
+    }
+    
+    private func migrateUserDefaultsIfNeeded() {
+        if let userDefaults = UserDefaults(suiteName: groupID),
+           !userDefaults.bool(forKey: Defaults.userDefaultsMigration.rawValue) {
+            let customDayStart = Defaults.customDayStart.rawValue
+            userDefaults.set(UserDefaults.standard.bool(forKey: customDayStart), forKey: customDayStart)
+            
+            let customDayStartMinutes = Defaults.customDayStartMinutes.rawValue
+            userDefaults.set(UserDefaults.standard.integer(forKey: customDayStartMinutes), forKey: customDayStartMinutes)
+            
+            let weekStartDay = Defaults.weekStartDay.rawValue
+            userDefaults.set(UserDefaults.standard.integer(forKey: weekStartDay), forKey: weekStartDay)
+            
+            userDefaults.set(true, forKey: Defaults.userDefaultsMigration.rawValue)
+            print("UserDefaults migrated")
+        }
     }
     
     //MARK: Date Formatters

--- a/Tickmate/Tickmate/Controllers/TrackController.swift
+++ b/Tickmate/Tickmate/Controllers/TrackController.swift
@@ -81,7 +81,9 @@ class TrackController: NSObject, ObservableObject {
     //MARK: Static
     
     static var dayOffset: DateComponents {
-        (UserDefaults.standard.bool(forKey: Defaults.customDayStart.rawValue) ? UserDefaults.standard.integer(forKey: Defaults.customDayStartMinutes.rawValue) : 0).minutes
+        (UserDefaults(suiteName: groupID)?.bool(forKey: Defaults.customDayStart.rawValue) ?? false
+            ? UserDefaults(suiteName: groupID)?.integer(forKey: Defaults.customDayStartMinutes.rawValue) ?? 0
+            : 0).minutes
     }
     
     private static func migrateUserDefaultsIfNeeded() {

--- a/Tickmate/Tickmate/Controllers/TrackController.swift
+++ b/Tickmate/Tickmate/Controllers/TrackController.swift
@@ -78,6 +78,8 @@ class TrackController: NSObject, ObservableObject {
         super.init()
     }
     
+    //MARK: Static
+    
     static var dayOffset: DateComponents {
         (UserDefaults.standard.bool(forKey: Defaults.customDayStart.rawValue) ? UserDefaults.standard.integer(forKey: Defaults.customDayStartMinutes.rawValue) : 0).minutes
     }
@@ -120,6 +122,8 @@ class TrackController: NSObject, ObservableObject {
         formatter.formatOptions = .withFullDate
         return formatter
     }()
+    
+    static let iso8601Full = ISO8601DateFormatter()
     
     //MARK: Ticks
     
@@ -263,6 +267,7 @@ class TrackController: NSObject, ObservableObject {
             self?.saveWork = nil
             guard let context = self?.fetchedResultsController.managedObjectContext else { return }
             PersistenceController.save(context: context)
+            self?.setLastUpdateTime()
             print("Saved")
         }
         saveWork = work
@@ -278,6 +283,10 @@ class TrackController: NSObject, ObservableObject {
         }
         refreshWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: work)
+    }
+    
+    func setLastUpdateTime() {
+        UserDefaults(suiteName: groupID)?.set(TrackController.iso8601Full.string(from: Date()), forKey: Defaults.lastUpdateTime.rawValue)
     }
     
     /// This will shortcut the 5-second wait from `scheduleSave()`.

--- a/Tickmate/Tickmate/Controllers/TrackController.swift
+++ b/Tickmate/Tickmate/Controllers/TrackController.swift
@@ -209,6 +209,7 @@ class TrackController: NSObject, ObservableObject {
             loadTicks(for: track)
         }
         PersistenceController.save(context: moc)
+        scheduleTimelineRefresh()
     }
     
     func updateTickDateOffsets(for track: Track, oldStartString: String?) {
@@ -254,6 +255,7 @@ class TrackController: NSObject, ObservableObject {
             // actually wouldn't make a difference because it displays its days based on
             // their date relative to today, regardless of the content of the TickControllers.
             tickControllers.values.forEach { $0.loadTicks() }
+            scheduleTimelineRefresh()
         }
     }
     
@@ -308,6 +310,7 @@ class TrackController: NSObject, ObservableObject {
             date = Date() - TrackController.dayOffset
             weekday = date.in(region: .current).weekday
             tickControllers.values.forEach { $0.loadTicks() }
+            scheduleTimelineRefresh()
             print("Updated from \(oldDate) to \(newDate)")
         }
     }

--- a/Tickmate/Tickmate/Model/Defaults.swift
+++ b/Tickmate/Tickmate/Model/Defaults.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+let groupID = "group.vc.isv.Tickmate"
+
 enum Defaults: String {
     case customDayStart             // Bool
     case customDayStartMinutes      // Int
@@ -19,4 +21,5 @@ enum Defaults: String {
     case showUngroupedTracks        // Bool
     case groupPage                  // Int
     case appGroupDatabaseMigration  // Bool
+    case userDefaultsMigration      // Bool
 }

--- a/Tickmate/Tickmate/Model/Defaults.swift
+++ b/Tickmate/Tickmate/Model/Defaults.swift
@@ -22,4 +22,5 @@ enum Defaults: String {
     case groupPage                  // Int
     case appGroupDatabaseMigration  // Bool
     case userDefaultsMigration      // Bool
+    case lastUpdateTime             // String
 }

--- a/Tickmate/Tickmate/Model/Defaults.swift
+++ b/Tickmate/Tickmate/Model/Defaults.swift
@@ -10,17 +10,17 @@ import Foundation
 let groupID = "group.vc.isv.Tickmate"
 
 enum Defaults: String {
-    case customDayStart             // Bool
-    case customDayStartMinutes      // Int
+    case customDayStart             // Bool     App Group
+    case customDayStartMinutes      // Int      App Group
     case weekSeparatorSpaces        // Bool
     case weekSeparatorLines         // Bool
-    case weekStartDay               // Int
+    case weekStartDay               // Int      App Group
     case relativeDates              // Bool
     case onboardingComplete         // Bool
     case showAllTracks              // Bool
     case showUngroupedTracks        // Bool
     case groupPage                  // Int
     case appGroupDatabaseMigration  // Bool
-    case userDefaultsMigration      // Bool
-    case lastUpdateTime             // String
+    case userDefaultsMigration      // Bool     App Group
+    case lastUpdateTime             // String   App Group
 }

--- a/Tickmate/Tickmate/Views/ContentView.swift
+++ b/Tickmate/Tickmate/Views/ContentView.swift
@@ -100,7 +100,7 @@ struct ContentView: View {
         .environmentObject(trackController)
         .environmentObject(groupController)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
-            trackController.scheduleSave(now: true)
+            trackController.saveIfScheduled()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             print("willEnterForeground")

--- a/Tickmate/Tickmate/Views/SettingsView.swift
+++ b/Tickmate/Tickmate/Views/SettingsView.swift
@@ -10,11 +10,15 @@ import SwiftDate
 
 struct SettingsView: View {
     
-    @AppStorage(Defaults.customDayStart.rawValue) private var customDayStart: Bool = false
-    @AppStorage(Defaults.customDayStartMinutes.rawValue) private var minutes: Int = 60
+    @AppStorage(Defaults.customDayStart.rawValue, store: UserDefaults(suiteName: groupID))
+    private var customDayStart: Bool = false
+    @AppStorage(Defaults.customDayStartMinutes.rawValue, store: UserDefaults(suiteName: groupID))
+    private var minutes: Int = 60
+    @AppStorage(Defaults.weekStartDay.rawValue, store: UserDefaults(suiteName: groupID))
+    private var weekStartDay = 2
+    
     @AppStorage(Defaults.weekSeparatorSpaces.rawValue) private var weekSeparatorSpaces: Bool = true
     @AppStorage(Defaults.weekSeparatorLines.rawValue) private var weekSeparatorLines: Bool = true
-    @AppStorage(Defaults.weekStartDay.rawValue) private var weekStartDay = 2
     @AppStorage(Defaults.relativeDates.rawValue) private var relativeDates = true
     
     @EnvironmentObject private var trackController: TrackController

--- a/Tickmate/Tickmate/Views/TickView.swift
+++ b/Tickmate/Tickmate/Views/TickView.swift
@@ -82,7 +82,7 @@ struct TickView: View {
     private var color: Color {
         // If the day is ticked, use the track color. Otherwise, use
         // system fill. If the track is reversed, reverse the check.
-        (tickController.getTick(for: day)?.count ?? 0 > 0) != track.reversed ? Color(rgb: Int(track.color)) : Color(.systemFill)
+        (tickController.tickCount(for: day) > 0) != track.reversed ? Color(rgb: Int(track.color)) : Color(.systemFill)
     }
     
     private var validDate: Bool {
@@ -101,7 +101,7 @@ struct TickView: View {
                     .foregroundColor(color)
                     .frame(height: compact ? 16 : 32)
             }
-            let count = tickController.getTick(for: day)?.count ?? 0
+            let count = tickController.tickCount(for: day)
             if count > 1 {
                 Text("\(count)")
                     .foregroundColor(track.lightText ? .white : .black)

--- a/Tickmate/Tickmate/Views/TickView.swift
+++ b/Tickmate/Tickmate/Views/TickView.swift
@@ -17,13 +17,19 @@ struct DayRow<C: RandomAccessCollection>: View where C.Element == Track {
     var tracks: C
     var spaces: Bool
     var lines: Bool
+    var widget: Bool
     var compact: Bool
     
-    init(_ day: Int, tracks: C, spaces: Bool, lines: Bool, compact: Bool = false) {
+    init(_ day: Int, tracks: C, spaces: Bool, lines: Bool) {
+        self.init(day, tracks: tracks, spaces: spaces, lines: lines, widget: false, compact: false)
+    }
+    
+    init(_ day: Int, tracks: C, spaces: Bool, lines: Bool, widget: Bool, compact: Bool) {
         self.day = day
         self.tracks = tracks
         self.spaces = spaces
         self.lines = lines
+        self.widget = widget
         self.compact = compact
     }
     
@@ -48,13 +54,13 @@ struct DayRow<C: RandomAccessCollection>: View where C.Element == Track {
                     .opacity(0)
             }
             HStack(spacing: 4) {
-                let label = trackController.dayLabel(day: day, compact: compact)
-                TextWithCaption(label.text, caption: compact ? nil : label.caption)
+                let label = trackController.dayLabel(day: day, compact: widget)
+                TextWithCaption(label.text, caption: widget ? nil : label.caption)
                     .lineLimit(1)
-                    .frame(width: compact ? 30 : 80, alignment: .leading)
+                    .frame(width: compact ? 30 : widget ? 50 : 80, alignment: .leading)
                     .font(compact ? .system(size: 11) : .body)
                 ForEach(tracks) { track in
-                    TickView(day: day, compact: compact, track: track, tickController: trackController.tickController(for: track))
+                    TickView(day: day, widget: widget, compact: compact, track: track, tickController: trackController.tickController(for: track))
                 }
             }
             if spaces && trackController.insets(day: day) == .bottom {
@@ -74,6 +80,7 @@ struct DayRow<C: RandomAccessCollection>: View where C.Element == Track {
 struct TickView: View {
     
     let day: Int
+    var widget: Bool
     var compact: Bool
     
     @ObservedObject var track: Track
@@ -93,18 +100,20 @@ struct TickView: View {
     
     var body: some View {
         ZStack {
-            if compact {
+            if widget {
                 RoundedRectangle(cornerRadius: 3)
                     .foregroundColor(color)
             } else {
                 RoundedRectangle(cornerRadius: 3)
                     .foregroundColor(color)
-                    .frame(height: compact ? 16 : 32)
+                    .frame(height: 32)
             }
             let count = tickController.tickCount(for: day)
             if count > 1 {
                 Text("\(count)")
+                    .lineLimit(1)
                     .foregroundColor(track.lightText ? .white : .black)
+                    .font(compact ? .system(size: 11) : .body)
             }
         }
         .onTapGesture {

--- a/Tickmate/Tickmate/Views/TicksView.swift
+++ b/Tickmate/Tickmate/Views/TicksView.swift
@@ -55,7 +55,7 @@ struct TicksView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
+            HStack(spacing: 4) {
                 Rectangle()
                     .opacity(0)
                     .frame(width: 80, height: 32)

--- a/Tickmate/Tickmate/Views/TracksView.swift
+++ b/Tickmate/Tickmate/Views/TracksView.swift
@@ -104,6 +104,7 @@ struct TracksView: View {
             trackController.delete(track: $0, context: moc)
         }
         trackController.scheduleSave()
+        trackController.scheduleTimelineRefresh()
     }
     
     private func move(_ indices: IndexSet, newOffset: Int) {
@@ -114,6 +115,7 @@ struct TracksView: View {
         }.forEach { $0.index = $1 }
         
         PersistenceController.save(context: moc)
+        trackController.scheduleTimelineRefresh()
     }
     
     private func select(track: Track, delay: Double) {

--- a/Tickmate/TicksWidget/TicksWidget.intentdefinition
+++ b/Tickmate/TicksWidget/TicksWidget.intentdefinition
@@ -53,7 +53,7 @@
 	<key>INIntentDefinitionNamespace</key>
 	<string>88xZPY</string>
 	<key>INIntentDefinitionSystemVersion</key>
-	<string>20E232</string>
+	<string>20F71</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
 	<string>12E507</string>
 	<key>INIntentDefinitionToolsVersion</key>
@@ -70,7 +70,7 @@
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
 			<key>INIntentLastParameterTag</key>
-			<integer>9</integer>
+			<integer>11</integer>
 			<key>INIntentName</key>
 			<string>Configuration</string>
 			<key>INIntentParameters</key>
@@ -79,11 +79,55 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
+					<string>Show Track Icons</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>dqt6E8</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>1</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataDefaultValue</key>
+						<true/>
+						<key>INIntentParameterMetadataFalseDisplayName</key>
+						<string>false</string>
+						<key>INIntentParameterMetadataFalseDisplayNameID</key>
+						<string>a07s9r</string>
+						<key>INIntentParameterMetadataTrueDisplayName</key>
+						<string>true</string>
+						<key>INIntentParameterMetadataTrueDisplayNameID</key>
+						<string>qzVovg</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>showTrackIcons</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+					</array>
+					<key>INIntentParameterTag</key>
+					<integer>11</integer>
+					<key>INIntentParameterType</key>
+					<string>Boolean</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
 					<string>Number of Days</string>
 					<key>INIntentParameterDisplayNameID</key>
 					<string>ZjGrrT</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>1</integer>
+					<integer>2</integer>
 					<key>INIntentParameterMetadata</key>
 					<dict>
 						<key>INIntentParameterMetadataDefaultValue</key>
@@ -125,7 +169,7 @@
 					<key>INIntentParameterDisplayNameID</key>
 					<string>9WcBEw</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>2</integer>
+					<integer>3</integer>
 					<key>INIntentParameterEnumType</key>
 					<string>TracksMode</string>
 					<key>INIntentParameterEnumTypeNamespace</key>
@@ -185,7 +229,7 @@
 					<key>INIntentParameterDisplayNameID</key>
 					<string>tZn7dI</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>3</integer>
+					<integer>4</integer>
 					<key>INIntentParameterName</key>
 					<string>tracks</string>
 					<key>INIntentParameterObjectType</key>
@@ -233,7 +277,7 @@
 					<key>INIntentParameterDisplayNameID</key>
 					<string>rrJ3QX</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>4</integer>
+					<integer>5</integer>
 					<key>INIntentParameterMetadata</key>
 					<dict>
 						<key>INIntentParameterMetadataDefaultValue</key>

--- a/Tickmate/TicksWidget/TicksWidget.intentdefinition
+++ b/Tickmate/TicksWidget/TicksWidget.intentdefinition
@@ -27,23 +27,76 @@
 				</dict>
 				<dict>
 					<key>INEnumValueDisplayName</key>
-					<string>Number</string>
+					<string>Auto</string>
 					<key>INEnumValueDisplayNameID</key>
 					<string>dPNsl6</string>
 					<key>INEnumValueIndex</key>
 					<integer>1</integer>
 					<key>INEnumValueName</key>
-					<string>number</string>
+					<string>automatic</string>
 				</dict>
 				<dict>
 					<key>INEnumValueDisplayName</key>
-					<string>List</string>
+					<string>Pick</string>
 					<key>INEnumValueDisplayNameID</key>
 					<string>YqewFi</string>
 					<key>INEnumValueIndex</key>
 					<integer>2</integer>
 					<key>INEnumValueName</key>
-					<string>list</string>
+					<string>choose</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Group</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>NaEO2G</string>
+					<key>INEnumValueIndex</key>
+					<integer>3</integer>
+					<key>INEnumValueName</key>
+					<string>group</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>INEnumDisplayName</key>
+			<string>Days Mode</string>
+			<key>INEnumDisplayNameID</key>
+			<string>Ap9ehh</string>
+			<key>INEnumGeneratesHeader</key>
+			<true/>
+			<key>INEnumName</key>
+			<string>DaysMode</string>
+			<key>INEnumType</key>
+			<string>Regular</string>
+			<key>INEnumValues</key>
+			<array>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>unknown</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>VzlN88</string>
+					<key>INEnumValueName</key>
+					<string>unknown</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Auto</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>NSEdvj</string>
+					<key>INEnumValueIndex</key>
+					<integer>1</integer>
+					<key>INEnumValueName</key>
+					<string>automatic</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Manual</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>M3m7GL</string>
+					<key>INEnumValueIndex</key>
+					<integer>2</integer>
+					<key>INEnumValueName</key>
+					<string>manual</string>
 				</dict>
 			</array>
 		</dict>
@@ -70,7 +123,7 @@
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
 			<key>INIntentLastParameterTag</key>
-			<integer>11</integer>
+			<integer>17</integer>
 			<key>INIntentName</key>
 			<string>Configuration</string>
 			<key>INIntentParameters</key>
@@ -123,17 +176,121 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Number of Days</string>
+					<string>Week Separators</string>
 					<key>INIntentParameterDisplayNameID</key>
-					<string>ZjGrrT</string>
+					<string>ueMN27</string>
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>2</integer>
 					<key>INIntentParameterMetadata</key>
 					<dict>
 						<key>INIntentParameterMetadataDefaultValue</key>
+						<true/>
+						<key>INIntentParameterMetadataFalseDisplayName</key>
+						<string>false</string>
+						<key>INIntentParameterMetadataFalseDisplayNameID</key>
+						<string>J1Mz4U</string>
+						<key>INIntentParameterMetadataTrueDisplayName</key>
+						<string>true</string>
+						<key>INIntentParameterMetadataTrueDisplayNameID</key>
+						<string>ifGrJw</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>weekSeparators</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+					</array>
+					<key>INIntentParameterTag</key>
+					<integer>17</integer>
+					<key>INIntentParameterType</key>
+					<string>Boolean</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Days Mode</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>oxptuM</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
+					<key>INIntentParameterEnumType</key>
+					<string>DaysMode</string>
+					<key>INIntentParameterEnumTypeNamespace</key>
+					<string>88xZPY</string>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataDefaultValue</key>
+						<string>automatic</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>daysMode</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} options matching ‘${daysMode}’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>uYeRhr</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${daysMode}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>5DwbMY</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterTag</key>
+					<integer>13</integer>
+					<key>INIntentParameterType</key>
+					<string>Integer</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Number of Days</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>ZjGrrT</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>4</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataDefaultValue</key>
 						<integer>5</integer>
 						<key>INIntentParameterMetadataMaximumValue</key>
-						<integer>8</integer>
+						<integer>10</integer>
 						<key>INIntentParameterMetadataMinimumValue</key>
 						<integer>1</integer>
 						<key>INIntentParameterMetadataType</key>
@@ -156,6 +313,15 @@
 							<string>Primary</string>
 						</dict>
 					</array>
+					<key>INIntentParameterRelationship</key>
+					<dict>
+						<key>INIntentParameterRelationshipParentName</key>
+						<string>daysMode</string>
+						<key>INIntentParameterRelationshipPredicateName</key>
+						<string>EnumHasExactValue</string>
+						<key>INIntentParameterRelationshipPredicateValue</key>
+						<string>manual</string>
+					</dict>
 					<key>INIntentParameterTag</key>
 					<integer>2</integer>
 					<key>INIntentParameterType</key>
@@ -165,11 +331,11 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Tracks to Display</string>
+					<string>Tracks</string>
 					<key>INIntentParameterDisplayNameID</key>
 					<string>9WcBEw</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>3</integer>
+					<integer>5</integer>
 					<key>INIntentParameterEnumType</key>
 					<string>TracksMode</string>
 					<key>INIntentParameterEnumTypeNamespace</key>
@@ -177,7 +343,7 @@
 					<key>INIntentParameterMetadata</key>
 					<dict>
 						<key>INIntentParameterMetadataDefaultValue</key>
-						<string>number</string>
+						<string>automatic</string>
 					</dict>
 					<key>INIntentParameterName</key>
 					<string>tracksMode</string>
@@ -225,11 +391,11 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Tracks</string>
+					<string>Selection</string>
 					<key>INIntentParameterDisplayNameID</key>
 					<string>tZn7dI</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>4</integer>
+					<integer>6</integer>
 					<key>INIntentParameterName</key>
 					<string>tracks</string>
 					<key>INIntentParameterObjectType</key>
@@ -258,7 +424,7 @@
 						<key>INIntentParameterRelationshipPredicateName</key>
 						<string>EnumHasExactValue</string>
 						<key>INIntentParameterRelationshipPredicateValue</key>
-						<string>list</string>
+						<string>choose</string>
 					</dict>
 					<key>INIntentParameterSupportsDynamicEnumeration</key>
 					<true/>
@@ -273,24 +439,17 @@
 					<key>INIntentParameterConfigurable</key>
 					<true/>
 					<key>INIntentParameterDisplayName</key>
-					<string>Number of Tracks</string>
+					<string>Group</string>
 					<key>INIntentParameterDisplayNameID</key>
-					<string>rrJ3QX</string>
+					<string>ctde9l</string>
 					<key>INIntentParameterDisplayPriority</key>
-					<integer>5</integer>
-					<key>INIntentParameterMetadata</key>
-					<dict>
-						<key>INIntentParameterMetadataDefaultValue</key>
-						<integer>4</integer>
-						<key>INIntentParameterMetadataMaximumValue</key>
-						<integer>6</integer>
-						<key>INIntentParameterMetadataMinimumValue</key>
-						<integer>1</integer>
-						<key>INIntentParameterMetadataType</key>
-						<string>Stepper</string>
-					</dict>
+					<integer>7</integer>
 					<key>INIntentParameterName</key>
-					<string>tracksCount</string>
+					<string>group</string>
+					<key>INIntentParameterObjectType</key>
+					<string>GroupItem</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>88xZPY</string>
 					<key>INIntentParameterPromptDialogs</key>
 					<array>
 						<dict>
@@ -313,12 +472,12 @@
 						<key>INIntentParameterRelationshipPredicateName</key>
 						<string>EnumHasExactValue</string>
 						<key>INIntentParameterRelationshipPredicateValue</key>
-						<string>number</string>
+						<string>group</string>
 					</dict>
 					<key>INIntentParameterTag</key>
-					<integer>9</integer>
+					<integer>15</integer>
 					<key>INIntentParameterType</key>
-					<string>Integer</string>
+					<string>Object</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>
@@ -358,6 +517,69 @@
 			<integer>100</integer>
 			<key>INTypeName</key>
 			<string>TrackItem</string>
+			<key>INTypeProperties</key>
+			<array>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>1</integer>
+					<key>INTypePropertyName</key>
+					<string>identifier</string>
+					<key>INTypePropertyTag</key>
+					<integer>1</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>2</integer>
+					<key>INTypePropertyName</key>
+					<string>displayString</string>
+					<key>INTypePropertyTag</key>
+					<integer>2</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>3</integer>
+					<key>INTypePropertyName</key>
+					<string>pronunciationHint</string>
+					<key>INTypePropertyTag</key>
+					<integer>3</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>4</integer>
+					<key>INTypePropertyName</key>
+					<string>alternativeSpeakableMatches</string>
+					<key>INTypePropertySupportsMultipleValues</key>
+					<true/>
+					<key>INTypePropertyTag</key>
+					<integer>4</integer>
+					<key>INTypePropertyType</key>
+					<string>SpeakableString</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>INTypeDisplayName</key>
+			<string>Group</string>
+			<key>INTypeDisplayNameID</key>
+			<string>zt9xSV</string>
+			<key>INTypeLastPropertyTag</key>
+			<integer>99</integer>
+			<key>INTypeName</key>
+			<string>GroupItem</string>
 			<key>INTypeProperties</key>
 			<array>
 				<dict>

--- a/Tickmate/TicksWidget/TicksWidget.swift
+++ b/Tickmate/TicksWidget/TicksWidget.swift
@@ -9,6 +9,7 @@ import WidgetKit
 import SwiftUI
 import Intents
 import CoreData
+import SwiftDate
 
 //MARK: Provider
 
@@ -36,10 +37,25 @@ struct Provider: IntentTimelineProvider {
         // To test refreshes, you can adjust this entry to be much sooner, like 15 seconds.
         // Just make sure you only run the widget connected to the debugger like that and don't
         // leave it on your home screen after you disconnect.
-        entries.append(Entry(date: Calendar.current.date(byAdding: .minute, value: 30, to: Date())!, configuration: configuration, controller: trackController, tracks: tracks))
+        
+        var nextEntryDate = Date() + 30.minutes
+        let offsetEntryDate = nextEntryDate - TrackController.dayOffset
+        
+        let currentDate = TrackController.iso8601.string(from: Date() - TrackController.dayOffset)
+        let newDate = TrackController.iso8601.string(from: offsetEntryDate)
+        if currentDate != newDate {
+            // The new day rollover is less than 30 minutes from now.
+            // Add a new timeline entry right at the new day rollover.
+            nextEntryDate = offsetEntryDate.dateAtStartOf([.day]) + TrackController.dayOffset
+            
+            print(offsetEntryDate.dateAtStartOf([.day]) + TrackController.dayOffset)
+        }
+        
+        entries.append(Entry(date: nextEntryDate, configuration: configuration, controller: trackController, tracks: tracks))
 
         let timeline = Timeline(entries: entries, policy: .atEnd)
         
+        // Check last sync time
         let lastSyncSeconds: Int
                 
         if let lastUpdateTimeString = UserDefaults(suiteName: groupID)?.string(forKey: Defaults.lastUpdateTime.rawValue),

--- a/Tickmate/TicksWidget/TicksWidget.swift
+++ b/Tickmate/TicksWidget/TicksWidget.swift
@@ -110,7 +110,8 @@ struct Provider: IntentTimelineProvider {
     
     private func tracksFetchRequest() -> NSFetchRequest<Track> {
         let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "index", ascending: true)]
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Track.index, ascending: true)]
+        fetchRequest.predicate = NSPredicate(format: "enabled == YES")
         fetchRequest.fetchLimit = 8
         return fetchRequest
     }
@@ -119,7 +120,9 @@ struct Provider: IntentTimelineProvider {
         guard let groupItem = groupItem,
               let group = object(for: groupItem, context: moc) else { return nil }
         let fetchRequest = tracksFetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "%@ in groups", group)
+        let groupsPredicate = NSPredicate(format: "%@ in groups", group)
+        let predicates = [fetchRequest.predicate, groupsPredicate].compactMap { $0 }
+        fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         return (try? moc.fetch(fetchRequest))
     }
 }

--- a/Tickmate/TicksWidget/TicksWidget.swift
+++ b/Tickmate/TicksWidget/TicksWidget.swift
@@ -84,6 +84,8 @@ struct TracksEntry: TimelineEntry {
 }
 
 struct TicksWidgetEntryView : View {
+    @Environment(\.colorScheme) private var colorScheme
+    
     var entry: Provider.Entry
     var numDays: Int {
         entry.configuration.numDays?.intValue ?? 5
@@ -117,6 +119,7 @@ struct TicksWidgetEntryView : View {
             }
         }
         .padding(12)
+        .background(colorScheme == .dark ? Color(.systemGroupedBackground) : Color(.systemBackground))
     }
     
     // You can uncomment this and the above Text for easier debugging
@@ -146,10 +149,18 @@ struct TicksWidget: Widget {
 
 struct TicksWidget_Previews: PreviewProvider {
     static let trackController = TrackController(observeChanges: false, preview: true)
+    static var tracks: [Track] {
+        Array(trackController.fetchedResultsController.fetchedObjects!.prefix(4))
+    }
     
     static var previews: some View {
-        TicksWidgetEntryView(entry: TracksEntry(date: Date(), configuration: ConfigurationIntent(), controller: trackController, tracks: Array(trackController.fetchedResultsController.fetchedObjects!.prefix(4))))
+        TicksWidgetEntryView(entry: TracksEntry(date: Date(), configuration: ConfigurationIntent(), controller: trackController, tracks: tracks))
             .previewContext(WidgetPreviewContext(family: .systemSmall))
             .environmentObject(trackController)
+        
+        TicksWidgetEntryView(entry: TracksEntry(date: Date(), configuration: ConfigurationIntent(), controller: trackController, tracks: tracks))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .environmentObject(trackController)
+            .environment(\.colorScheme, .dark)
     }
 }

--- a/Tickmate/TicksWidget/TicksWidget.swift
+++ b/Tickmate/TicksWidget/TicksWidget.swift
@@ -92,11 +92,31 @@ struct TicksWidgetEntryView : View {
     var body: some View {
         VStack(spacing: 4) {
 //            Text(entry.date, formatter: dateFormatter)
+            if entry.configuration.showTrackIcons?.boolValue ?? true {
+                HStack(spacing: 4) {
+                    Rectangle()
+                        .opacity(0)
+                        .frame(width: 30)
+                    ForEach(entry.tracks) { track in
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 3)
+                                .foregroundColor(Color(.systemFill))
+                            if let systemImage = track.systemImage {
+                                Image(systemName: systemImage)
+                                    .font(.system(size: 8))
+                            }
+                        }
+                    }
+                }
+                
+                Divider()
+            }
+            
             ForEach(0..<numDays) { dayComplement in
                 DayRow(numDays - 1 - dayComplement, tracks: entry.tracks, spaces: false, lines: false, compact: true)
             }
         }
-        .padding()
+        .padding(12)
     }
     
     // You can uncomment this and the above Text for easier debugging

--- a/Tickmate/TicksWidget/TicksWidget.swift
+++ b/Tickmate/TicksWidget/TicksWidget.swift
@@ -10,6 +10,8 @@ import SwiftUI
 import Intents
 import CoreData
 
+//MARK: Provider
+
 struct Provider: IntentTimelineProvider {
     func placeholder(in context: Context) -> TracksEntry {
         TracksEntry(date: Date(), configuration: ConfigurationIntent())
@@ -75,21 +77,38 @@ struct Provider: IntentTimelineProvider {
     }
     
     private func tracks(for configuration: ConfigurationIntent, context moc: NSManagedObjectContext) -> [Track]? {
-        (configuration.tracksMode != .list ? nil : configuration.tracks?.compactMap { trackItem in
-            guard let idString = trackItem.identifier,
-                  let url = URL(string: idString),
-                  let id =
-                    moc.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url)  else { return nil }
-            return moc.object(with: id) as? Track
-        }) ??? {
-            let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
-            fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Track.index, ascending: true)]
-            fetchRequest.fetchLimit = configuration.tracksCount?.intValue ?? 1
-            
-            return (try? moc.fetch(fetchRequest))
-        }()
+        // This isn't using a switch statement because chaining ??? operators allows it to fall
+        // back to the default fetch request if the results are nil, OR if they're empty.
+        (configuration.tracksMode == .choose ? configuration.tracks?.prefix(8).compactMap { object(for: $0, context: moc) } : nil)
+        ??? (configuration.tracksMode == .group ? getTracks(for: configuration.group, context: moc) : nil)
+        ??? (try? moc.fetch(tracksFetchRequest()))
+    }
+    
+    private func object<T: NSManagedObject>(for inObject: INObject, context moc: NSManagedObjectContext) -> T? {
+        guard let idString = inObject.identifier,
+              let url = URL(string: idString),
+              let id =
+                moc.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url)  else { return nil }
+        return moc.object(with: id) as? T
+    }
+    
+    private func tracksFetchRequest() -> NSFetchRequest<Track> {
+        let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "index", ascending: true)]
+        fetchRequest.fetchLimit = 8
+        return fetchRequest
+    }
+    
+    private func getTracks(for groupItem: GroupItem?, context moc: NSManagedObjectContext) -> [Track]? {
+        guard let groupItem = groupItem,
+              let group = object(for: groupItem, context: moc) else { return nil }
+        let fetchRequest = tracksFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "%@ in groups", group)
+        return (try? moc.fetch(fetchRequest))
     }
 }
+
+//MARK: TracksEntry
 
 struct TracksEntry: TimelineEntry {
     let date: Date
@@ -105,13 +124,88 @@ struct TracksEntry: TimelineEntry {
     }
 }
 
+//MARK: TicksWidgetEntryView
+
 struct TicksWidgetEntryView : View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.widgetFamily) private var widgetFamily
+    
+    //MARK: Properties
     
     var entry: Provider.Entry
-    var numDays: Int {
-        entry.configuration.numDays?.intValue ?? 5
+    
+    var bonusDays: Int {
+        (!(entry.configuration.showTrackIcons?.boolValue ?? true)).int
     }
+    
+    var defaultNumDays: Int {
+        switch widgetFamily {
+        case .systemSmall:
+            return 5 + bonusDays
+        case .systemMedium:
+            return 4 + bonusDays
+        default:
+            return 7 + bonusDays
+        }
+    }
+    
+    var maxNumDays: Int {
+        switch widgetFamily {
+        case .systemSmall, .systemMedium:
+            return 6 + bonusDays
+        default:
+            return 9 + bonusDays
+        }
+    }
+    
+    var numDays: Int {
+        entry.configuration.daysMode == .automatic
+            ? defaultNumDays
+            : min(entry.configuration.numDays?.intValue ?? defaultNumDays, maxNumDays)
+    }
+    
+    var defaultNumTracks: Int {
+        switch widgetFamily {
+        case .systemSmall:
+            return 4
+        case .systemMedium:
+            return 6
+        default:
+            return 5
+        }
+    }
+    
+    var maxNumTracks: Int {
+        switch widgetFamily {
+        case .systemSmall:
+            return 6
+        default:
+            return 8
+        }
+    }
+    
+    var numTracks: Int {
+        switch entry.configuration.tracksMode {
+        case .automatic,
+             // If .choose or .group are selected but the user doesn't make
+             // a choice, it falls back to the default fetch request.
+             .choose where entry.configuration.tracks?.isEmpty ?? true,
+             .group where entry.configuration.group == nil:
+            return defaultNumTracks
+        default:
+            return maxNumTracks
+        }
+    }
+    
+    var tracks: Array<Track>.SubSequence {
+        entry.tracks.prefix(numTracks)
+    }
+    
+    var compact: Bool {
+        [.systemSmall, .systemMedium].contains(widgetFamily)
+    }
+    
+    //MARK: Body
 
     var body: some View {
         VStack(spacing: 4) {
@@ -120,24 +214,38 @@ struct TicksWidgetEntryView : View {
                 HStack(spacing: 4) {
                     Rectangle()
                         .opacity(0)
-                        .frame(width: 30)
-                    ForEach(entry.tracks) { track in
+                        .frame(width: compact ? 30 : 50)
+                    ForEach(tracks) { track in
                         ZStack {
                             RoundedRectangle(cornerRadius: 3)
                                 .foregroundColor(Color(.systemFill))
                             if let systemImage = track.systemImage {
                                 Image(systemName: systemImage)
-                                    .font(.system(size: 8))
+                                    .font(compact ? .system(size: 11) : .body)
                             }
                         }
                     }
                 }
+                .frame(maxHeight: 30)
                 
                 Divider()
             }
             
             ForEach(0..<numDays) { dayComplement in
-                DayRow(numDays - 1 - dayComplement, tracks: entry.tracks, spaces: false, lines: false, compact: true)
+                let day = numDays - 1 - dayComplement
+                DayRow(day, tracks: tracks, spaces: false, lines: false, widget: true, compact: compact)
+                
+                if dayComplement < numDays - 1 {
+                    if entry.configuration.weekSeparators?.boolValue ?? true
+                        && entry.trackController.weekend(day: day) {
+                        Capsule()
+                            .foregroundColor(.gray)
+                            .frame(height: 2)
+                            .padding(.vertical, compact ? 0 : 2)
+                    } else if !compact {
+                        Divider()
+                    }
+                }
             }
         }
         .padding(12)
@@ -155,6 +263,8 @@ struct TicksWidgetEntryView : View {
     */
 }
 
+//MARK: TicksWidget
+
 @main
 struct TicksWidget: Widget {
     let kind: String = "TicksWidget"
@@ -169,20 +279,33 @@ struct TicksWidget: Widget {
     }
 }
 
+//MARK: Previews
+
 struct TicksWidget_Previews: PreviewProvider {
     static let trackController = TrackController(observeChanges: false, preview: true)
-    static var tracks: [Track] {
-        Array(trackController.fetchedResultsController.fetchedObjects!.prefix(4))
-    }
     
     static var previews: some View {
-        TicksWidgetEntryView(entry: TracksEntry(date: Date(), configuration: ConfigurationIntent(), controller: trackController, tracks: tracks))
-            .previewContext(WidgetPreviewContext(family: .systemSmall))
-            .environmentObject(trackController)
-        
-        TicksWidgetEntryView(entry: TracksEntry(date: Date(), configuration: ConfigurationIntent(), controller: trackController, tracks: tracks))
-            .previewContext(WidgetPreviewContext(family: .systemSmall))
-            .environmentObject(trackController)
+        ticksWidget(tracksCount: 3, days: 2, family: .systemSmall)
+        ticksWidget(tracksCount: 4, days: 5, family: .systemSmall)
             .environment(\.colorScheme, .dark)
+        ticksWidget(tracksCount: 5, days: 4, family: .systemMedium)
+        ticksWidget(tracksCount: 4, days: 7, family: .systemLarge)
+        ticksWidget(tracksCount: 5, days: 10, family: .systemLarge)
+    }
+    
+    static func tracks(_ count: Int) -> [Track] {
+        Array(trackController.fetchedResultsController.fetchedObjects!.prefix(count))
+    }
+    
+    static func ticksWidget(tracksCount: Int, days: Int, family: WidgetFamily) -> some View {
+        TicksWidgetEntryView(entry: TracksEntry(date: Date(), configuration: config(days: days), controller: trackController, tracks: tracks(tracksCount)))
+            .environmentObject(trackController)
+            .previewContext(WidgetPreviewContext(family: family))
+    }
+    
+    static func config(days: Int) -> ConfigurationIntent {
+        let config = ConfigurationIntent()
+        config.numDays = NSNumber(integerLiteral: days)
+        return config
     }
 }

--- a/Tickmate/TicksWidgetExtension.entitlements
+++ b/Tickmate/TicksWidgetExtension.entitlements
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.vc.isv.Tickmate</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.vc.isv.Tickmate</string>

--- a/Tickmate/TicksWidgetIntentsExtension/IntentHandler.swift
+++ b/Tickmate/TicksWidgetIntentsExtension/IntentHandler.swift
@@ -33,4 +33,20 @@ class IntentHandler: INExtension, ConfigurationIntentHandling {
         }
     }
     
+    func provideGroupOptionsCollection(for intent: ConfigurationIntent, with completion: @escaping (INObjectCollection<GroupItem>?, Error?) -> Void) {
+        let fetchRequest: NSFetchRequest<TrackGroup> = TrackGroup.fetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \TrackGroup.index, ascending: true)]
+        
+        do {
+            let context = PersistenceController.shared.container.viewContext
+            let groups: [GroupItem] = try context.fetch(fetchRequest).compactMap { group in
+                let id = group.objectID.uriRepresentation().absoluteString
+                return GroupItem(identifier: id, display: group.name ??? "New Group")
+            }
+            completion(INObjectCollection(items: groups), nil)
+        } catch {
+            completion(nil, error)
+        }
+    }
+    
 }


### PR DESCRIPTION
Make the widget read Ticks directly from CloudKit instead of Core Data so that it can stay up-to-date with multi-device sync.