### PR TITLE
Add backup and restore feature

### DIFF
--- a/Tickmate/Tickmate.xcodeproj/project.pbxproj
+++ b/Tickmate/Tickmate.xcodeproj/project.pbxproj
@@ -93,7 +93,10 @@
 		59FBCF2825E07BD8007B114F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59FBCF2725E07BD8007B114F /* Preview Assets.xcassets */; };
 		59FBCF2A25E07BD8007B114F /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FBCF2925E07BD8007B114F /* Persistence.swift */; };
 		59FBCF2D25E07BD8007B114F /* Tickmate.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 59FBCF2B25E07BD8007B114F /* Tickmate.xcdatamodeld */; };
+		284CA9E37503DCEDF441EBD2 /* BackupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF544BC9C1A5CC2273208EF /* BackupView.swift */; };
+		5198C3D8759F57D0366A0472 /* BackupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850B118309D524F90AAD4272 /* BackupController.swift */; };
 		B90C7F252DA0D92100C8F12B /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C7F242DA0D92000C8F12B /* ShareSheet.swift */; };
+		E3F9C9FCC7F19CC6C32231FE /* BackupArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E61840640BB655EA8C4430 /* BackupArchive.swift */; };
 		B91ED2862B5B89640049EDB7 /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = B91ED2852B5B89640049EDB7 /* SwiftUIIntrospect */; };
 		B93BBF092B9CCAFC007E810A /* ArchivedTracksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93BBF082B9CCAFC007E810A /* ArchivedTracksView.swift */; };
 		B95E5FA52DAB479E002FD0AB /* TrackTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95E5FA42DAB479E002FD0AB /* TrackTableViewController.swift */; };
@@ -199,7 +202,10 @@
 		59FBCF2925E07BD8007B114F /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		59FBCF2C25E07BD8007B114F /* Tickmate.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Tickmate.xcdatamodel; sourceTree = "<group>"; };
 		59FBCF2E25E07BD8007B114F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2FF544BC9C1A5CC2273208EF /* BackupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupView.swift; sourceTree = "<group>"; };
+		850B118309D524F90AAD4272 /* BackupController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupController.swift; sourceTree = "<group>"; };
 		B90C7F242DA0D92000C8F12B /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
+		D8E61840640BB655EA8C4430 /* BackupArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupArchive.swift; sourceTree = "<group>"; };
 		B93BBF082B9CCAFC007E810A /* ArchivedTracksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedTracksView.swift; sourceTree = "<group>"; };
 		B95E5FA22DAB479E002FD0AB /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		B95E5FA32DAB479E002FD0AB /* PageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewController.swift; sourceTree = "<group>"; };
@@ -365,6 +371,7 @@
 				59E6E15025F8837E008A74A9 /* Defaults.swift */,
 				5904EAAE2657111300B2D0A0 /* Binding+onChange.swift */,
 				59303A502665D00900EB900E /* TrackGroups.swift */,
+				D8E61840640BB655EA8C4430 /* BackupArchive.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -387,6 +394,7 @@
 				59342E1B2603F3DF007E9F64 /* OnboardingView.swift */,
 				5996360E264F128A00AAF6CA /* GroupsView.swift */,
 				592CE889264F1CA800668684 /* GroupView.swift */,
+				2FF544BC9C1A5CC2273208EF /* BackupView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -400,6 +408,7 @@
 				592850F1265EF54B00E682F5 /* GroupController.swift */,
 				59F3EDC125FC4F270009CDEC /* ViewControllerContainer.swift */,
 				59603D442666C85A001482C6 /* StoreController.swift */,
+				850B118309D524F90AAD4272 /* BackupController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -660,6 +669,9 @@
 				597A7FDD25F6E1C900256268 /* StateEditButton.swift in Sources */,
 				59E6E14E25F88177008A74A9 /* SettingsView.swift in Sources */,
 				5931643F26855EB8005DDA1A /* TickView.swift in Sources */,
+				E3F9C9FCC7F19CC6C32231FE /* BackupArchive.swift in Sources */,
+				5198C3D8759F57D0366A0472 /* BackupController.swift in Sources */,
+				284CA9E37503DCEDF441EBD2 /* BackupView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tickmate/Tickmate/Controllers/BackupController.swift
+++ b/Tickmate/Tickmate/Controllers/BackupController.swift
@@ -1,0 +1,308 @@
+//
+//  BackupController.swift
+//  Tickmate
+//
+//  Created by Elaine Lyons on 5/12/26.
+//
+
+import CoreData
+import Foundation
+
+enum ImportMode {
+    case replace
+    case merge
+}
+
+enum BackupError: LocalizedError {
+    case newerVersion(Int)
+    case invalidFormat
+    case readFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .newerVersion(let version):
+            return "This backup was made with a newer version of Tickmate (format version \(version)). Please update the app before importing."
+        case .invalidFormat:
+            return "The file is not a valid Tickmate backup."
+        case .readFailed:
+            return "Could not read the backup file."
+        }
+    }
+}
+
+struct BackupController {
+
+    // MARK: - Encoder / Decoder
+
+    static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    // MARK: - Export
+
+    static func export(
+        tracks: [Track],
+        includeSettings: Bool
+    ) throws -> URL {
+        var archive = BackupArchive()
+        archive.appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        archive.appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+        archive.exportDate = Date()
+
+        // Build group map: CoreData object -> synthetic UUID
+        var groupIDMap: [NSManagedObjectID: String] = [:]
+        var referencedGroups = Set<NSManagedObjectID>()
+
+        // Determine which groups are referenced by the selected tracks
+        for track in tracks {
+            if let groups = track.groups as? Set<TrackGroup> {
+                for group in groups {
+                    referencedGroups.insert(group.objectID)
+                    if groupIDMap[group.objectID] == nil {
+                        groupIDMap[group.objectID] = UUID().uuidString
+                    }
+                }
+            }
+        }
+
+        // Export referenced groups, sorted by index for stable output
+        var backupGroups: [BackupGroup] = []
+        let referencedGroupObjects = tracks
+            .compactMap { $0.groups as? Set<TrackGroup> }
+            .flatMap { $0 }
+            .filter { referencedGroups.contains($0.objectID) }
+        let seen = NSMutableSet()
+        for group in referencedGroupObjects.sorted(by: { $0.index < $1.index }) {
+            guard !seen.contains(group.objectID) else { continue }
+            seen.add(group.objectID)
+            let uuid = groupIDMap[group.objectID]!
+            backupGroups.append(BackupGroup(
+                id: uuid,
+                index: group.index,
+                name: group.name
+            ))
+        }
+        archive.groups = backupGroups
+
+        // Export selected tracks
+        var backupTracks: [BackupTrack] = []
+        for track in tracks {
+            let trackGroupIDs: [String] = (track.groups as? Set<TrackGroup>)?.compactMap { groupIDMap[$0.objectID] } ?? []
+
+            var backupTicks: [BackupTick] = []
+            if let ticks = track.ticks as? Set<Tick> {
+                for tick in ticks.sorted(by: { $0.dayOffset < $1.dayOffset }) {
+                    backupTicks.append(BackupTick(
+                        dayOffset: tick.dayOffset,
+                        count: tick.count,
+                        duplicate: tick.duplicate,
+                        modified: tick.modified
+                    ))
+                }
+            }
+
+            backupTracks.append(BackupTrack(
+                id: UUID().uuidString,
+                name: track.name,
+                color: track.color,
+                enabled: track.enabled,
+                index: track.index,
+                isArchived: track.isArchived,
+                multiple: track.multiple,
+                reversed: track.reversed,
+                startDate: track.startDate,
+                systemImage: track.systemImage,
+                groupIDs: trackGroupIDs,
+                ticks: backupTicks
+            ))
+        }
+        archive.tracks = backupTracks
+
+        // Settings
+        if includeSettings {
+            archive.settings = readSettings()
+        }
+
+        let data = try encoder.encode(archive)
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateString = dateFormatter.string(from: Date())
+        let filename = "Tickmate Backup \(dateString).tickmatebackup"
+
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try data.write(to: url)
+        return url
+    }
+
+    // MARK: - Import
+
+    static func importBackup(
+        from url: URL,
+        mode: ImportMode,
+        restoreSettings: Bool
+    ) throws {
+        let context = PersistenceController.shared.container.viewContext
+        guard url.startAccessingSecurityScopedResource() || true else {
+            throw BackupError.readFailed
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw BackupError.readFailed
+        }
+
+        let archive: BackupArchive
+        do {
+            archive = try decoder.decode(BackupArchive.self, from: data)
+        } catch {
+            throw BackupError.invalidFormat
+        }
+
+        guard archive.format == "tickmate-backup" else {
+            throw BackupError.invalidFormat
+        }
+
+        if archive.formatVersion > BackupArchive.currentFormatVersion {
+            throw BackupError.newerVersion(archive.formatVersion)
+        }
+
+        // Replace mode: delete all existing data
+        if mode == .replace {
+            try batchDelete(entity: "Tick", context: context)
+            try batchDelete(entity: "Track", context: context)
+            try batchDelete(entity: "TrackGroup", context: context)
+        }
+
+        // Import groups, mapping backup UUIDs to new Core Data objects
+        var groupMap: [String: TrackGroup] = [:]
+        if let groups = archive.groups {
+            for backupGroup in groups {
+                let group = TrackGroup(
+                    name: backupGroup.name,
+                    index: backupGroup.index ?? 0,
+                    context: context
+                )
+                if let id = backupGroup.id {
+                    groupMap[id] = group
+                }
+            }
+        }
+
+        // Import tracks with their ticks
+        if let tracks = archive.tracks {
+            for backupTrack in tracks {
+                let track = Track(
+                    name: backupTrack.name ?? "",
+                    color: backupTrack.color,
+                    multiple: backupTrack.multiple ?? false,
+                    reversed: backupTrack.reversed ?? false,
+                    startDate: backupTrack.startDate ?? TrackController.iso8601.string(from: Date()),
+                    systemImage: backupTrack.systemImage,
+                    index: backupTrack.index ?? 0,
+                    isArchived: backupTrack.isArchived ?? false,
+                    context: context
+                )
+                track.enabled = backupTrack.enabled ?? true
+
+                // Wire up group relationships
+                if let groupIDs = backupTrack.groupIDs {
+                    let groups = groupIDs.compactMap { groupMap[$0] }
+                    track.groups = NSSet(array: groups)
+                }
+
+                // Import ticks
+                if let ticks = backupTrack.ticks {
+                    for backupTick in ticks {
+                        let tick = Tick(
+                            track: track,
+                            dayOffset: backupTick.dayOffset ?? 0,
+                            context: context
+                        )
+                        tick.count = backupTick.count ?? 1
+                        tick.duplicate = backupTick.duplicate ?? false
+                        if let modified = backupTick.modified {
+                            tick.modified = modified
+                        }
+                    }
+                }
+            }
+        }
+
+        // Settings
+        if restoreSettings, let settings = archive.settings {
+            writeSettings(settings)
+        }
+
+        // Unlock groups if the backup contains any
+        if !groupMap.isEmpty {
+            UserDefaults.standard.set(true, forKey: StoreController.Products.groups.rawValue)
+        }
+
+        try context.save()
+    }
+
+    // MARK: - Settings helpers
+
+    private static func readSettings() -> BackupSettings {
+        let standard = UserDefaults.standard
+        let appGroup = UserDefaults(suiteName: groupID)
+
+        return BackupSettings(
+            customDayStart: appGroup?.bool(forKey: Defaults.customDayStart.rawValue),
+            customDayStartMinutes: appGroup?.integer(forKey: Defaults.customDayStartMinutes.rawValue),
+            weekStartDay: appGroup?.integer(forKey: Defaults.weekStartDay.rawValue),
+            weekSeparatorSpaces: standard.bool(forKey: Defaults.weekSeparatorSpaces.rawValue),
+            weekSeparatorLines: standard.bool(forKey: Defaults.weekSeparatorLines.rawValue),
+            relativeDates: standard.bool(forKey: Defaults.relativeDates.rawValue),
+            showAllTracks: standard.bool(forKey: Defaults.showAllTracks.rawValue),
+            showUngroupedTracks: standard.bool(forKey: Defaults.showUngroupedTracks.rawValue),
+            todayAtTop: appGroup?.bool(forKey: Defaults.todayAtTop.rawValue),
+            todayLock: appGroup?.bool(forKey: Defaults.todayLock.rawValue)
+        )
+    }
+
+    static func writeSettings(_ settings: BackupSettings) {
+        let standard = UserDefaults.standard
+        let appGroup = UserDefaults(suiteName: groupID)
+
+        if let v = settings.customDayStart { appGroup?.set(v, forKey: Defaults.customDayStart.rawValue) }
+        if let v = settings.customDayStartMinutes { appGroup?.set(v, forKey: Defaults.customDayStartMinutes.rawValue) }
+        if let v = settings.weekStartDay { appGroup?.set(v, forKey: Defaults.weekStartDay.rawValue) }
+        if let v = settings.weekSeparatorSpaces { standard.set(v, forKey: Defaults.weekSeparatorSpaces.rawValue) }
+        if let v = settings.weekSeparatorLines { standard.set(v, forKey: Defaults.weekSeparatorLines.rawValue) }
+        if let v = settings.relativeDates { standard.set(v, forKey: Defaults.relativeDates.rawValue) }
+        if let v = settings.showAllTracks { standard.set(v, forKey: Defaults.showAllTracks.rawValue) }
+        if let v = settings.showUngroupedTracks { standard.set(v, forKey: Defaults.showUngroupedTracks.rawValue) }
+        if let v = settings.todayAtTop { appGroup?.set(v, forKey: Defaults.todayAtTop.rawValue) }
+        if let v = settings.todayLock { appGroup?.set(v, forKey: Defaults.todayLock.rawValue) }
+    }
+
+    // MARK: - Helpers
+
+    private static func batchDelete(entity: String, context: NSManagedObjectContext) throws {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entity)
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        deleteRequest.resultType = .resultTypeObjectIDs
+
+        let result = try context.execute(deleteRequest) as? NSBatchDeleteResult
+        if let objectIDs = result?.result as? [NSManagedObjectID] {
+            NSManagedObjectContext.mergeChanges(
+                fromRemoteContextSave: [NSDeletedObjectsKey: objectIDs],
+                into: [context]
+            )
+        }
+    }
+}

--- a/Tickmate/Tickmate/Controllers/StoreController.swift
+++ b/Tickmate/Tickmate/Controllers/StoreController.swift
@@ -27,15 +27,33 @@ class StoreController: NSObject, ObservableObject {
     @Published var restored: AlertItem?
     
     private var isRestoringPurchases = false
-    
+    private var groupsObserver: NSObjectProtocol?
+
     var isAuthorizedForPayments: Bool {
         SKPaymentQueue.canMakePayments()
     }
-    
+
     override init() {
         groupsUnlocked = UserDefaults.standard.bool(forKey: Products.groups.rawValue)
         super.init()
         SKPaymentQueue.default().add(self)
+
+        groupsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { [weak self] _ in
+            let current = UserDefaults.standard.bool(forKey: Products.groups.rawValue)
+            if self?.groupsUnlocked != current {
+                self?.groupsUnlocked = current
+            }
+        }
+    }
+
+    deinit {
+        if let observer = groupsObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
     
     var priceFormatter: NumberFormatter = {

--- a/Tickmate/Tickmate/Info.plist
+++ b/Tickmate/Tickmate/Info.plist
@@ -24,6 +24,44 @@
 	<array>
 		<string>ConfigurationIntent</string>
 	</array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Tickmate Backup</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>app.lyons.Tickmate.backup</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+				<string>public.text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Tickmate Backup</string>
+			<key>UTTypeIdentifier</key>
+			<string>app.lyons.Tickmate.backup</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tickmatebackup</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/json</string>
+			</dict>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Tickmate/Tickmate/Model/BackupArchive.swift
+++ b/Tickmate/Tickmate/Model/BackupArchive.swift
@@ -1,0 +1,67 @@
+//
+//  BackupArchive.swift
+//  Tickmate
+//
+//  Created by Elaine Lyons on 5/12/26.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+extension UTType {
+    static let tickmateBackup = UTType(exportedAs: "app.lyons.Tickmate.backup")
+}
+
+struct BackupArchive: Codable {
+    static let currentFormatVersion = 1
+
+    var format: String = "tickmate-backup"
+    var formatVersion: Int = Self.currentFormatVersion
+    var appVersion: String?
+    var appBuild: String?
+    var exportDate: Date?
+    var settings: BackupSettings?
+    var groups: [BackupGroup]?
+    var tracks: [BackupTrack]?
+}
+
+struct BackupSettings: Codable {
+    var customDayStart: Bool?
+    var customDayStartMinutes: Int?
+    var weekStartDay: Int?
+    var weekSeparatorSpaces: Bool?
+    var weekSeparatorLines: Bool?
+    var relativeDates: Bool?
+    var showAllTracks: Bool?
+    var showUngroupedTracks: Bool?
+    var todayAtTop: Bool?
+    var todayLock: Bool?
+}
+
+struct BackupGroup: Codable {
+    var id: String?
+    var index: Int16?
+    var name: String?
+}
+
+struct BackupTrack: Codable {
+    var id: String?
+    var name: String?
+    var color: Int32?
+    var enabled: Bool?
+    var index: Int16?
+    var isArchived: Bool?
+    var multiple: Bool?
+    var reversed: Bool?
+    var startDate: String?
+    var systemImage: String?
+    var groupIDs: [String]?
+    var ticks: [BackupTick]?
+}
+
+struct BackupTick: Codable {
+    var dayOffset: Int16?
+    var count: Int16?
+    var duplicate: Bool?
+    var modified: Date?
+}

--- a/Tickmate/Tickmate/TickmateApp.swift
+++ b/Tickmate/Tickmate/TickmateApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct TickmateApp: App {
     let persistenceController = PersistenceController.shared
-        .loadDemo() // Uncomment this to load demo data into a fresh install
+//        .loadDemo() // Uncomment this to load demo data into a fresh install
 
     @AppStorage(Defaults.useNewUI.rawValue) var useNewUI = false
     @Environment(\.scenePhase) private var scenePhase

--- a/Tickmate/Tickmate/Views/BackupView.swift
+++ b/Tickmate/Tickmate/Views/BackupView.swift
@@ -1,0 +1,223 @@
+//
+//  BackupView.swift
+//  Tickmate
+//
+//  Created by Elaine Lyons on 5/12/26.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BackupView: View {
+    @EnvironmentObject private var trackController: TrackController
+
+    @State private var selectedTracks: Set<Track> = []
+    @State private var allAreSelected = false
+    @State private var includeSettings = true
+    @State private var exportFile: BackupFile?
+    @State private var isExporting = false
+
+    @State private var isImporting = false
+    @State private var pendingImportURL: URL?
+    @State private var isImportInProgress = false
+
+    @State private var activeAlert: ActiveAlert?
+
+    private enum ActiveAlert: Identifiable {
+        case importConfirm
+        case result(title: String, message: String)
+
+        var id: String {
+            switch self {
+            case .importConfirm: return "importConfirm"
+            case .result(let title, _): return "result-\(title)"
+            }
+        }
+    }
+
+    private struct BackupFile: Identifiable {
+        let url: URL
+        var id: URL { url }
+    }
+
+    private var allTracks: [Track] {
+        let active = trackController.fetchedResultsController.fetchedObjects ?? []
+        let archived = trackController.archivedTracksFRC.fetchedObjects ?? []
+        return active + archived
+    }
+
+    var body: some View {
+        List {
+            exportSection
+            importSection
+        }
+        .navigationTitle("Backup & Restore")
+        .sheet(item: $exportFile) { file in
+            ShareSheet(activityItems: [file.url])
+        }
+        .fileImporter(
+            isPresented: $isImporting,
+            allowedContentTypes: [.tickmateBackup, .json],
+            onCompletion: didPickImportFile
+        )
+        .alert(item: $activeAlert) { item in
+            switch item {
+            case .importConfirm:
+                return Alert(
+                    title: Text("Import Backup"),
+                    message: Text("Replace will delete all existing data before importing. Merge will add imported data alongside existing data.\n\nChanges will sync to all your devices via iCloud."),
+                    primaryButton: .destructive(Text("Replace All")) {
+                        performImport(mode: .replace)
+                    },
+                    secondaryButton: .default(Text("Merge")) {
+                        performImport(mode: .merge)
+                    }
+                )
+            case .result(let title, let message):
+                return Alert(title: Text(title), message: Text(message))
+            }
+        }
+    }
+
+    // MARK: - Export
+
+    private var exportSection: some View {
+        Section {
+            Toggle("Include Settings", isOn: $includeSettings)
+
+            Button(allAreSelected ? "Deselect All" : "Select All") {
+                if allAreSelected {
+                    selectedTracks.removeAll()
+                } else {
+                    selectedTracks = Set(allTracks)
+                }
+            }
+
+            ForEach(allTracks, id: \.self) { track in
+                Button {
+                    selectedTracks.toggle(track)
+                } label: {
+                    HStack {
+                        Image(systemName: selectedTracks.contains(track) ? "checkmark.circle.fill" : "circle")
+                            .foregroundColor(selectedTracks.contains(track) ? .accentColor : .secondary)
+                        if let systemImage = track.systemImage {
+                            Image(systemName: systemImage)
+                                .resizable()
+                                .scaledToFit()
+                                .padding(6)
+                                .frame(width: 36, height: 36)
+                                .foregroundColor(track.lightText ? .white : .black)
+                                .background(
+                                    Color(rgb: Int(track.color))
+                                        .cornerRadius(4)
+                                )
+                        }
+                        Text(track.name ?? "Unnamed Track")
+                            .foregroundColor(.primary)
+                        if track.isArchived {
+                            Text("(Archived)")
+                                .foregroundColor(.secondary)
+                                .font(.caption)
+                        }
+                    }
+                }
+            }
+
+            Button("Export Backup") {
+                exportBackup()
+            }
+            .disabled(selectedTracks.isEmpty && !includeSettings)
+        } header: {
+            Text("Export")
+        } footer: {
+            Text("Groups containing selected tracks will be included automatically.")
+        }
+        .onAppear {
+            selectedTracks = Set(allTracks)
+        }
+        .onChange(of: selectedTracks) { _ in
+            allAreSelected = selectedTracks.count == allTracks.count
+        }
+    }
+
+    // MARK: - Import
+
+    private var importSection: some View {
+        Section {
+            Button("Import from File") {
+                isImporting = true
+            }
+            .disabled(isImportInProgress)
+
+            if isImportInProgress {
+                HStack {
+                    ProgressView()
+                    Text("Importing...")
+                        .foregroundColor(.secondary)
+                }
+            }
+        } header: {
+            Text("Import")
+        } footer: {
+            Text("Import a .tickmatebackup or .json file previously exported from Tickmate.")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func exportBackup() {
+        guard !isExporting else { return }
+        isExporting = true
+        defer { isExporting = false }
+
+        do {
+            let url = try BackupController.export(
+                tracks: Array(selectedTracks),
+                includeSettings: includeSettings
+            )
+            exportFile = BackupFile(url: url)
+        } catch {
+            activeAlert = .result(title: "Export Failed", message: error.localizedDescription)
+        }
+    }
+
+    private func didPickImportFile(_ result: Result<URL, Error>) {
+        switch result {
+        case .success(let url):
+            pendingImportURL = url
+            activeAlert = .importConfirm
+        case .failure(let error):
+            activeAlert = .result(title: "Could not open file", message: error.localizedDescription)
+        }
+    }
+
+    private func performImport(mode: ImportMode) {
+        guard let url = pendingImportURL else { return }
+        isImportInProgress = true
+
+        DispatchQueue.main.async {
+            do {
+                try BackupController.importBackup(
+                    from: url,
+                    mode: mode,
+                    restoreSettings: true
+                )
+                activeAlert = .result(title: "Import Successful", message: "Your data has been restored.")
+            } catch {
+                activeAlert = .result(title: "Import Failed", message: error.localizedDescription)
+            }
+            pendingImportURL = nil
+            isImportInProgress = false
+        }
+    }
+}
+
+struct BackupView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            BackupView()
+        }
+        .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+        .environmentObject(TrackController(preview: true))
+    }
+}

--- a/Tickmate/Tickmate/Views/SettingsView.swift
+++ b/Tickmate/Tickmate/Views/SettingsView.swift
@@ -165,7 +165,8 @@ struct SettingsView: View {
                 NavigationLink("Acknowledgements", destination: AcknowledgementsView())
             }
             
-            Section(header: Text("Data Export")) {
+            Section(header: Text("Backup & Export")) {
+                NavigationLink("Backup & Restore", destination: BackupView())
                 NavigationLink("Export as CSV", destination: ExportTracksSelectionView())
             }
             


### PR DESCRIPTION
## Summary

- Adds full backup/restore functionality for tracks, groups, and settings
- Implemented `BackupController` with export and import logic supporting selective track export
- Provides UI in settings with options to select tracks, include settings, and choose import mode (replace/merge)
- Registers `.tickmatebackup` file type so backups can be opened directly from Files app
- Handles format versioning to detect incompatible backup versions
- Automatically unlocks groups feature when importing backups that contain groups
- Updates `StoreController` to observe UserDefaults changes for reactive UI updates

## Testing

- [x] Export backup with selected tracks and settings
- [x] Export backup with only settings (no tracks selected)
- [x] Verify exported file can be opened via file picker
- [x] Import backup in replace mode clears all existing data
- [x] Import backup in merge mode preserves existing data
- [x] Settings (day start, week display, etc.) are restored correctly
- [x] Track groups are recreated and relationships are preserved
- [x] Ticks and track properties (colors, icons, archived status) are restored
- [ ] Error handling for corrupted backup files
- [ ] Error handling for backup from newer app version
- [x] Groups unlock automatically after importing backup with groups
- [x] Share sheet appears after export for saving/sharing backup file
