### PR TITLE
Align week separator spacing and insets across table views

### DIFF
--- a/Tickmate/Tickmate.xcodeproj/project.pbxproj
+++ b/Tickmate/Tickmate.xcodeproj/project.pbxproj
@@ -719,7 +719,7 @@
 				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = A4525544Q4;
 				INFOPLIST_FILE = TicksWidget/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -744,7 +744,7 @@
 				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = A4525544Q4;
 				INFOPLIST_FILE = TicksWidget/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -767,7 +767,7 @@
 				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = A4525544Q4;
 				INFOPLIST_FILE = TicksWidgetIntentsExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -790,7 +790,7 @@
 				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = A4525544Q4;
 				INFOPLIST_FILE = TicksWidgetIntentsExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -937,7 +937,7 @@
 				DEVELOPMENT_TEAM = A4525544Q4;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Tickmate/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -966,7 +966,7 @@
 				DEVELOPMENT_TEAM = A4525544Q4;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Tickmate/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Tickmate/Tickmate/New UI/DayTableViewCell.swift
+++ b/Tickmate/Tickmate/New UI/DayTableViewCell.swift
@@ -25,13 +25,33 @@ class DayTableViewCell: UITableViewCell {
     /// engaged on a non-today day) interactions just notify the delegate.
     private var canEdit: Bool = true
 
+    /// Base whitespace opened up between weeks (below the buttons of the row
+    /// above each separator) when separator spaces are enabled. Tuned to match
+    /// the gap the SwiftUI `TicksView` produces via its invisible spacer +
+    /// default `VStack` spacing.
+    static let weekSeparatorBaseSpacing: CGFloat = 18
+    /// Thickness of the week-separator line.
+    static let weekSeparatorLineHeight: CGFloat = 4
+
+    /// Extra height the host adds (via `heightForRowAt`) to the row above each
+    /// week separator, which we pull the stack up by here so it becomes visible
+    /// space below the buttons. When the line is drawn it adds its own height
+    /// to the gap and is centered within it — mirroring `TicksView`, whose
+    /// spacer is `lines ? lineHeight : 0`, so weeks sit the same distance apart
+    /// whether or not the line is shown. Both `heightForRowAt` implementations
+    /// must use this so the date column and page tables stay scroll-synced.
+    static func weekSeparatorExtraHeight(lines: Bool) -> CGFloat {
+        weekSeparatorBaseSpacing + (lines ? weekSeparatorLineHeight : 0)
+    }
+
     private var stackView = UIStackView()
     /// Top/bottom constraints between `stackView` and the cell's `contentView`.
     /// We squeeze the stack view away from one edge to make room for
-    /// week-separator spacing — `heightForRowAt` makes the row 8pt taller for
-    /// the row above each separator, and the constant on `stackBottomConstraint`
-    /// pulls the stack up so the extra height becomes visible space between
-    /// weeks instead of vanishing into the cell.
+    /// week-separator spacing — `heightForRowAt` makes the row
+    /// `weekSeparatorExtraHeight` taller for the row above each separator, and
+    /// the constant on `stackBottomConstraint` pulls the stack up so the extra
+    /// height becomes visible space between weeks instead of vanishing into the
+    /// cell.
     private var stackTopConstraint: NSLayoutConstraint!
     private var stackBottomConstraint: NSLayoutConstraint!
     private var separatorLine: UIView?
@@ -107,29 +127,41 @@ class DayTableViewCell: UITableViewCell {
         separatorLine = nil
 
         // Configure week separator spacing. The row's height (set by the host
-        // `heightForRowAt`) is 8pt taller for the row directly above each
-        // separator; here we shrink the stack view by the same amount so that
-        // 8pt becomes a visible gap between weeks rather than padding that
-        // expands the buttons. Spacing is always added on the bottom edge so
-        // the gap sits in display order between this week and the next.
+        // `heightForRowAt`) is `weekSeparatorExtraHeight` taller for the row
+        // directly above each separator; here we shrink the stack view by the
+        // same amount so that height becomes a visible gap between weeks rather
+        // than padding that expands the buttons. Spacing is always added on the
+        // bottom edge so the gap sits in display order between this week and
+        // the next.
         let needsSeparatorSpace = weekSeparatorSpaces
             && TrackController.shared.shouldShowSeparatorBelow(day: day)
         stackTopConstraint.constant = 0
-        stackBottomConstraint.constant = needsSeparatorSpace ? -8 : 0
+        stackBottomConstraint.constant = needsSeparatorSpace
+            ? -Self.weekSeparatorExtraHeight(lines: weekSeparatorLines)
+            : 0
 
-        // Configure week separator line
+        // Configure week separator line. When separator spacing is present we
+        // center the line vertically within the gap (matching SwiftUI, where
+        // the line sits midway between the two weeks); otherwise it pins to the
+        // row's bottom edge.
         if weekSeparatorLines && TrackController.shared.shouldShowSeparatorBelow(day: day) {
             let line = UIView()
             line.backgroundColor = .gray
             line.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview(line)
+            // We're inside `weekSeparatorLines`, so the gap includes the line's
+            // height; center the line within it. With spaces off there's no
+            // gap, so the line pins to the bottom edge.
+            let lineBottomInset = needsSeparatorSpace
+                ? (Self.weekSeparatorExtraHeight(lines: true) - Self.weekSeparatorLineHeight) / 2
+                : 0
             NSLayoutConstraint.activate([
                 line.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 120),
                 line.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
-                line.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-                line.heightAnchor.constraint(equalToConstant: 4)
+                line.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -lineBottomInset),
+                line.heightAnchor.constraint(equalToConstant: Self.weekSeparatorLineHeight)
             ])
-            line.layer.cornerRadius = 2
+            line.layer.cornerRadius = Self.weekSeparatorLineHeight / 2
             line.clipsToBounds = true
             separatorLine = line
         }

--- a/Tickmate/Tickmate/New UI/DayTableViewCell.swift
+++ b/Tickmate/Tickmate/New UI/DayTableViewCell.swift
@@ -25,6 +25,19 @@ class DayTableViewCell: UITableViewCell {
     /// engaged on a non-today day) interactions just notify the delegate.
     private var canEdit: Bool = true
 
+    /// Leading inset for the week-separator line: flush with the trailing edge
+    /// of the date column (`ViewController.tableViewContainer`, 100pt wide and
+    /// opaque, overlaid on the left of the full-width page table). Keeping it
+    /// here avoids the line poking out from under the date grid as the page
+    /// slides during horizontal paging.
+    static let separatorLeadingInset: CGFloat = 100
+
+    /// Leading inset for the normal cell separators: a touch further in than the
+    /// week-separator line, so the (thicker) week line reads as slightly wider /
+    /// more prominent. Still clears the date column so it doesn't poke out under
+    /// the date grid while paging.
+    static let normalSeparatorLeadingInset: CGFloat = separatorLeadingInset + 8
+
     /// Base whitespace opened up between weeks (below the buttons of the row
     /// above each separator) when separator spaces are enabled. Tuned to match
     /// the gap the SwiftUI `TicksView` produces via its invisible spacer +
@@ -70,6 +83,8 @@ class DayTableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        selectionStyle = .none
 
         stackView.alignment = .center
         stackView.distribution = .fillEqually
@@ -156,12 +171,16 @@ class DayTableViewCell: UITableViewCell {
                 ? (Self.weekSeparatorExtraHeight(lines: true) - Self.weekSeparatorLineHeight) / 2
                 : 0
             NSLayoutConstraint.activate([
-                line.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 120),
-                line.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+                // Span the same width as the normal cell separators — flush with
+                // the date column's trailing edge through to the trailing edge —
+                // rather than the narrower button column.
+                line.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.separatorLeadingInset),
+                line.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
                 line.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -lineBottomInset),
                 line.heightAnchor.constraint(equalToConstant: Self.weekSeparatorLineHeight)
             ])
             line.layer.cornerRadius = Self.weekSeparatorLineHeight / 2
+            line.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
             line.clipsToBounds = true
             separatorLine = line
         }

--- a/Tickmate/Tickmate/New UI/TrackTableViewController.swift
+++ b/Tickmate/Tickmate/New UI/TrackTableViewController.swift
@@ -429,19 +429,25 @@ extension TrackTableViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        // Hide the system cell separator on the row above each week separator.
-        // We draw our own line centered in the gap there; the system hairline
-        // sits at the cell's bottom edge and would otherwise show as a faint
-        // second line just above the next week's first row. Only hide it when
-        // both the line and the spacing are on — otherwise our line sits at the
-        // bottom edge (coinciding with the system one) or there's no gap at all.
-        // Always reset on other rows so reused cells don't keep the hidden inset.
+        // Inset the system cell separators to start just past the date column's
+        // trailing edge rather than running the full (under-the-date-column)
+        // cell width — otherwise horizontal paging slides the page table out
+        // and reveals the separators poking out from under the date grid. They
+        // sit slightly further in than the week-separator line (see
+        // `normalSeparatorLeadingInset`).
+        //
+        // On the row above each week separator, hide the system hairline
+        // entirely: we draw our own line centered in the gap there, and the
+        // system one would show as a faint second line just above the next
+        // week's first row. Only hide when both the line and the spacing are on
+        // — otherwise our line sits at the bottom edge (coinciding with the
+        // system one) or there's no gap at all.
         let day = day(forRow: indexPath.row)
         let hideSystemSeparator = weekSeparatorLines && weekSeparatorSpaces
             && TrackController.shared.shouldShowSeparatorBelow(day: day)
         cell.separatorInset = hideSystemSeparator
             ? UIEdgeInsets(top: 0, left: tableView.bounds.width, bottom: 0, right: 0)
-            : tableView.separatorInset
+            : UIEdgeInsets(top: 0, left: DayTableViewCell.normalSeparatorLeadingInset, bottom: 0, right: 0)
     }
 
     // No `viewForHeaderInSection` / `heightForHeaderInSection`: the per-page

--- a/Tickmate/Tickmate/New UI/TrackTableViewController.swift
+++ b/Tickmate/Tickmate/New UI/TrackTableViewController.swift
@@ -422,7 +422,8 @@ extension TrackTableViewController: UITableViewDelegate {
         let day = day(forRow: indexPath.row)
         let baseHeight: CGFloat = 44
         if weekSeparatorSpaces && TrackController.shared.shouldShowSeparatorBelow(day: day) {
-            return baseHeight + 8 // Add 8 points of spacing for week separators
+            // Extra height that opens the gap between weeks (see DayTableViewCell).
+            return baseHeight + DayTableViewCell.weekSeparatorExtraHeight(lines: weekSeparatorLines)
         }
         return baseHeight
     }

--- a/Tickmate/Tickmate/New UI/TrackTableViewController.swift
+++ b/Tickmate/Tickmate/New UI/TrackTableViewController.swift
@@ -428,6 +428,22 @@ extension TrackTableViewController: UITableViewDelegate {
         return baseHeight
     }
 
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        // Hide the system cell separator on the row above each week separator.
+        // We draw our own line centered in the gap there; the system hairline
+        // sits at the cell's bottom edge and would otherwise show as a faint
+        // second line just above the next week's first row. Only hide it when
+        // both the line and the spacing are on — otherwise our line sits at the
+        // bottom edge (coinciding with the system one) or there's no gap at all.
+        // Always reset on other rows so reused cells don't keep the hidden inset.
+        let day = day(forRow: indexPath.row)
+        let hideSystemSeparator = weekSeparatorLines && weekSeparatorSpaces
+            && TrackController.shared.shouldShowSeparatorBelow(day: day)
+        cell.separatorInset = hideSystemSeparator
+            ? UIEdgeInsets(top: 0, left: tableView.bounds.width, bottom: 0, right: 0)
+            : tableView.separatorInset
+    }
+
     // No `viewForHeaderInSection` / `heightForHeaderInSection`: the per-page
     // TracksHeaderView lives outside the table now (see viewDidLoad), so
     // there's no section header at all.

--- a/Tickmate/Tickmate/New UI/ViewController.swift
+++ b/Tickmate/Tickmate/New UI/ViewController.swift
@@ -66,6 +66,12 @@ class ViewController: UIViewController {
     @AppStorage(Defaults.weekSeparatorSpaces.rawValue)
     private var weekSeparatorSpaces: Bool = true
 
+    // Needed alongside `weekSeparatorSpaces` so the date-column row heights
+    // match the page tables exactly (the separator gap depends on whether the
+    // line is drawn — see `DayTableViewCell.weekSeparatorExtraHeight`).
+    @AppStorage(Defaults.weekSeparatorLines.rawValue)
+    private var weekSeparatorLines: Bool = true
+
     /// Cached value used to detect when `todayAtTop` flips so the sidebar can
     /// be re-scrolled to match the page table's new "rest" edge.
     private var previousTodayAtTop: Bool = false
@@ -580,9 +586,10 @@ extension ViewController: UITableViewDelegate {
         // Has to gate on `weekSeparatorSpaces` for the same reason
         // `TrackTableViewController.heightForRowAt` does — otherwise disabling
         // separator spaces shrinks page rows back to 44pt while the sidebar
-        // keeps its 52pt rows, drifting the two scroll views apart.
+        // keeps its taller separator rows, drifting the two scroll views apart.
+        // The bump must match the page table's exactly to keep them in sync.
         if weekSeparatorSpaces && TrackController.shared.shouldShowSeparatorBelow(day: day) {
-            return baseHeight + 8 // Add 8 points of spacing for week separators
+            return baseHeight + DayTableViewCell.weekSeparatorExtraHeight(lines: weekSeparatorLines)
         }
         return baseHeight
     }


### PR DESCRIPTION
## Summary

- Unified week separator spacing constants (`weekSeparatorBaseSpacing`, `weekSeparatorLineHeight`, `weekSeparatorExtraHeight`) to keep the date column sidebar and page tables scroll-synced
- Inset cell separators to start at the trailing edge of the date column (100pt) so they don't peek out during horizontal paging
- Hide system cell separators on rows above week separator lines to avoid a faint double-line effect; draw a custom centered line instead
- Center the week separator line vertically within the gap (matching SwiftUI `TicksView` behavior)
- Added `weekSeparatorLines` property to `ViewController` to gate row height calculations on both line *and* spacing state
- Raised deployment target to iOS 15.0

## Testing

- [ ] Scroll vertically in the new UIKit UI and verify week gaps are consistent between the date column and page tables
- [ ] Enable week separator lines and spaces; verify the line is centered in the gap and spans the full width (not just the button column)
- [ ] Perform horizontal page scrolling (left/right); verify cell separators do not poke out from under the date grid
- [ ] Disable week separator spaces via settings; verify rows shrink back to 44pt and both tables stay in sync
- [ ] Disable week separator lines via settings (with spaces on); verify the gap remains but the centered line disappears
- [ ] Toggle between on/off for both settings and confirm no visual artifacts or scroll drift