### PR TITLE
Replace long-press decrement with popover count stepper

### DIFF
--- a/Tickmate/Tickmate.xcodeproj/project.pbxproj
+++ b/Tickmate/Tickmate.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		B9641FA02FB4FC0500F32DCC /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9641F9F2FB4FC0500F32DCC /* NotificationController.swift */; };
 		B9641FA12FB4FC0500F32DCC /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9641F9F2FB4FC0500F32DCC /* NotificationController.swift */; };
 		B9641FA22FB4FC0500F32DCC /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9641F9F2FB4FC0500F32DCC /* NotificationController.swift */; };
+		B9C57E901111111111111101 /* CountStepperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C57E901111111111111102 /* CountStepperViewController.swift */; };
 		B9E609ED2DA0EDDA00C00B44 /* ExportTracksSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E609EC2DA0EDDA00C00B44 /* ExportTracksSelectionView.swift */; };
 		E3F9C9FCC7F19CC6C32231FE /* BackupArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E61840640BB655EA8C4430 /* BackupArchive.swift */; };
 /* End PBXBuildFile section */
@@ -222,6 +223,7 @@
 		B95E5FB02DAB4A2B002FD0AB /* DayTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTableViewCell.swift; sourceTree = "<group>"; };
 		B95E5FB42DAB5983002FD0AB /* TracksHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksHeaderView.swift; sourceTree = "<group>"; };
 		B9641F9F2FB4FC0500F32DCC /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
+		B9C57E901111111111111102 /* CountStepperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountStepperViewController.swift; sourceTree = "<group>"; };
 		B9E609EC2DA0EDDA00C00B44 /* ExportTracksSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTracksSelectionView.swift; sourceTree = "<group>"; };
 		D8E61840640BB655EA8C4430 /* BackupArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupArchive.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -433,6 +435,7 @@
 				B95E5FB42DAB5983002FD0AB /* TracksHeaderView.swift */,
 				B95E5FA42DAB479E002FD0AB /* TrackTableViewController.swift */,
 				B95E5FB02DAB4A2B002FD0AB /* DayTableViewCell.swift */,
+				B9C57E901111111111111102 /* CountStepperViewController.swift */,
 				B95E5FAC2DAB48B4002FD0AB /* TracksContainer.swift */,
 				B95E5FAA2DAB47EF002FD0AB /* Defaults+Convenience.swift */,
 			);
@@ -653,6 +656,7 @@
 				592850F2265EF54B00E682F5 /* GroupController.swift in Sources */,
 				59EF632925E5CD4B003E7259 /* TrackView.swift in Sources */,
 				B95E5FB32DAB4A2B002FD0AB /* DayTableViewCell.swift in Sources */,
+				B9C57E901111111111111101 /* CountStepperViewController.swift in Sources */,
 				59C23A6725E70D7000AFBC4B /* SymbolsList.swift in Sources */,
 				5991968F25F813ED003215CC /* PresetTracksView.swift in Sources */,
 				59D483C027057E3300CB30C0 /* View+Conditional.swift in Sources */,

--- a/Tickmate/Tickmate/Controllers/TickController.swift
+++ b/Tickmate/Tickmate/Controllers/TickController.swift
@@ -200,6 +200,11 @@ class TickController: NSObject, ObservableObject {
             if track.multiple {
                 tick.count += 1
                 tick.modified = Date()
+                // Re-assign the array element so `$ticks` republishes. The FRC
+                // delegate only fires for inserts/deletes, so an in-place count
+                // change on an existing tick would otherwise leave subscribers
+                // (e.g. the UIKit DayTableViewCell button) showing a stale value.
+                ticks[day] = tick
                 save()
             } else {
                 untick(day: day)
@@ -222,6 +227,9 @@ class TickController: NSObject, ObservableObject {
         } else {
             tick.count -= 1
             tick.modified = Date()
+            // See tick(day:): re-publish so an in-place decrement refreshes
+            // subscribers immediately rather than waiting on a save/FRC event.
+            ticks[day] = tick
         }
         save()
         if day == 0, let context = track.managedObjectContext {

--- a/Tickmate/Tickmate/New UI/CountStepperViewController.swift
+++ b/Tickmate/Tickmate/New UI/CountStepperViewController.swift
@@ -1,0 +1,96 @@
+//
+//  CountStepperViewController.swift
+//  Tickmate
+//
+//  Created by Elaine Lyons on 6/15/26.
+//
+
+import UIKit
+import Combine
+
+/// Small popover content shown when the user taps a multiple-mode track cell
+/// that already has a count of 1 or more. Presents a `−  +` stepper so the
+/// count for that day can be adjusted up or down — replacing the old
+/// long-press-to-decrement gesture.
+///
+/// There's no value label here: the count is already shown on the track button
+/// the popover is anchored to. Increment/decrement route through the same
+/// `TickController` the cell uses; we observe its `$ticks` publisher only to
+/// disable `−` once the count reaches 0. There's no explicit clear button.
+class CountStepperViewController: UIViewController {
+
+    private let tickController: TickController
+    private let day: Int
+
+    private let decrementButton = UIButton(type: .system)
+    private let incrementButton = UIButton(type: .system)
+
+    private var subscriptions = Set<AnyCancellable>()
+
+    init(tickController: TickController, day: Int) {
+        self.tickController = tickController
+        self.day = day
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .popover
+        preferredContentSize = CGSize(width: 116, height: 48)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        decrementButton.setImage(UIImage(systemName: "minus"), for: .normal)
+        decrementButton.accessibilityLabel = "Decrease count"
+        decrementButton.addAction(UIAction { [weak self] _ in self?.decrement() }, for: .primaryActionTriggered)
+
+        incrementButton.setImage(UIImage(systemName: "plus"), for: .normal)
+        incrementButton.accessibilityLabel = "Increase count"
+        incrementButton.addAction(UIAction { [weak self] _ in self?.increment() }, for: .primaryActionTriggered)
+
+        let stack = UIStackView(arrangedSubviews: [decrementButton, incrementButton])
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.distribution = .fillEqually
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+
+        // Keep the `−` button's enabled state in sync with the underlying tick
+        // count so it can't drive the count below 0. We read from the published
+        // array directly (rather than `ticks(on:)`) because the controller
+        // updates the array before that convenience accessor reflects it.
+        tickController.$ticks
+            .sink { [weak self] allTicks in
+                guard let self else { return }
+                let count = allTicks.indices.contains(self.day)
+                    ? Int(allTicks[self.day]?.count ?? 0)
+                    : 0
+                self.decrementButton.isEnabled = count > 0
+            }
+            .store(in: &subscriptions)
+
+        decrementButton.isEnabled = tickController.ticks(on: day) > 0
+    }
+
+    private func increment() {
+        UISelectionFeedbackGenerator().selectionChanged()
+        tickController.tick(day: day)
+    }
+
+    private func decrement() {
+        // `untick(day:)` returns false if there's no tick to remove, in which
+        // case skip the haptic.
+        if tickController.untick(day: day) {
+            UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+        }
+    }
+}

--- a/Tickmate/Tickmate/New UI/DayTableViewCell.swift
+++ b/Tickmate/Tickmate/New UI/DayTableViewCell.swift
@@ -13,6 +13,16 @@ import Combine
 /// shows an alert after two consecutive taps.
 protocol DayTableViewCellDelegate: AnyObject {
     func dayCell(_ cell: DayTableViewCell, didTapLockedDayAt day: Int)
+
+    /// Asks the host to present the count stepper for a multiple-mode track
+    /// that already has a count of 1 or more. Anchored to `sourceView` (the
+    /// tapped tick button).
+    func dayCell(
+        _ cell: DayTableViewCell,
+        didRequestStepperFor track: Track,
+        day: Int,
+        from sourceView: UIView
+    )
 }
 
 class DayTableViewCell: UITableViewCell {
@@ -69,13 +79,6 @@ class DayTableViewCell: UITableViewCell {
     private var stackBottomConstraint: NSLayoutConstraint!
     private var separatorLine: UIView?
     private var buttons: [Track: UIButton] = [:]
-
-    /// Maps each tick button to its long-press recognizer (so we can rebuild
-    /// recognizer state cleanly when the cell is reconfigured).
-    private var longPressRecognizers: [UIButton: UILongPressGestureRecognizer] = [:]
-    /// Set of buttons that are currently scaled up because the user is
-    /// holding them down. Used to revert the scale on cancel/end.
-    private var pressedButtons: Set<UIButton> = []
 
     weak var delegate: DayTableViewCellDelegate?
 
@@ -188,10 +191,6 @@ class DayTableViewCell: UITableViewCell {
         subscriptions.forEach { $0.cancel() }
         subscriptions.removeAll()
 
-        // Reset any leftover scaling from the previous configuration.
-        pressedButtons.forEach { $0.transform = .identity }
-        pressedButtons.removeAll()
-
         tracks.enumerated().forEach { index, track in
             let tickController = TrackController.shared.tickController(for: track)
             let ticks = tickController.ticks(on: day)
@@ -204,10 +203,6 @@ class DayTableViewCell: UITableViewCell {
             NSLayoutConstraint.activate([
                 button.heightAnchor.constraint(equalToConstant: 34)
             ])
-
-            // Make sure the long-press recognizer is hooked up. Only attach
-            // one for tracks that allow multiple ticks per day.
-            configureLongPress(for: button, track: track, tickController: tickController)
 
             // Set up publisher to respond to changes
             tickController.$ticks.sink { [weak self] allTicks in
@@ -226,13 +221,23 @@ class DayTableViewCell: UITableViewCell {
             return button
         }
 
-        let button = UIButton(primaryAction: UIAction { [weak tickController, weak self] _ in
-            guard let self, let tickController else { return }
+        let button = UIButton(primaryAction: UIAction { [weak tickController, weak track, weak self] action in
+            guard let self, let tickController, let track,
+                  let button = action.sender as? UIButton else { return }
             // If today-lock is engaged on a previous day, route the tap to the
             // delegate (which will surface the alert via TrackController) and
             // bail out without mutating any ticks.
             guard self.canEdit else {
                 self.delegate?.dayCell(self, didTapLockedDayAt: self.day)
+                return
+            }
+            // For a multiple-mode track that already has a count, a tap opens
+            // the stepper so the user can adjust up or down. The first tick
+            // (0 -> 1) still happens on a plain tap, so adding a single count
+            // stays fast and the stepper only appears once there's a count to
+            // adjust.
+            if track.multiple, tickController.ticks(on: self.day) >= 1 {
+                self.delegate?.dayCell(self, didRequestStepperFor: track, day: self.day, from: button)
                 return
             }
             UISelectionFeedbackGenerator().selectionChanged()
@@ -241,73 +246,6 @@ class DayTableViewCell: UITableViewCell {
 
         buttons[track] = button
         return button
-    }
-
-    private func configureLongPress(for button: UIButton, track: Track, tickController: TickController) {
-        // Tear down any old recognizer so we never have stale state when a
-        // cell is reused with a different track / canEdit value.
-        if let existing = longPressRecognizers.removeValue(forKey: button) {
-            button.removeGestureRecognizer(existing)
-        }
-
-        // Only attach a recognizer to "multiple"-mode tracks; single-tick
-        // tracks already untick on a normal tap, so a long press would be
-        // redundant (and would cause a double mutation).
-        guard track.multiple else { return }
-
-        let recognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
-        recognizer.minimumPressDuration = 0.5
-        // Don't cancel the underlying touch — we still want the button to
-        // appear pressed while the user holds it.
-        recognizer.cancelsTouchesInView = false
-        button.addGestureRecognizer(recognizer)
-        longPressRecognizers[button] = recognizer
-    }
-
-    @objc private func handleLongPress(_ recognizer: UILongPressGestureRecognizer) {
-        guard let button = recognizer.view as? UIButton,
-              let track = buttons.first(where: { $0.value === button })?.key else { return }
-        let tickController = TrackController.shared.tickController(for: track)
-
-        switch recognizer.state {
-        case .began:
-            // Mirror the SwiftUI scale-up animation while the user is holding.
-            UIView.animate(withDuration: 0.6,
-                           delay: 0,
-                           options: [.beginFromCurrentState, .curveEaseInOut]) {
-                button.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
-            }
-            pressedButtons.insert(button)
-        case .ended:
-            // Animate the scale back down regardless of whether we end up
-            // unticking. (If we don't untick — e.g. canEdit is false — the
-            // animation is the only feedback the user gets.)
-            UIView.animate(withDuration: 0.2,
-                           delay: 0,
-                           options: [.beginFromCurrentState, .curveEaseInOut]) {
-                button.transform = .identity
-            }
-            pressedButtons.remove(button)
-
-            guard canEdit else {
-                delegate?.dayCell(self, didTapLockedDayAt: day)
-                return
-            }
-            // `untick(day:)` returns false if there's no tick to remove,
-            // in which case skip the haptic.
-            if tickController.untick(day: day) {
-                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-            }
-        case .cancelled, .failed:
-            UIView.animate(withDuration: 0.2,
-                           delay: 0,
-                           options: [.beginFromCurrentState, .curveEaseInOut]) {
-                button.transform = .identity
-            }
-            pressedButtons.remove(button)
-        default:
-            break
-        }
     }
 
     func configure(button: UIButton, for track: Track, ticks: Int) {

--- a/Tickmate/Tickmate/New UI/TrackTableViewController.swift
+++ b/Tickmate/Tickmate/New UI/TrackTableViewController.swift
@@ -518,6 +518,39 @@ extension TrackTableViewController: DayTableViewCellDelegate {
         // logic the SwiftUI version uses.
         trackController?.didTapLockedDay()
     }
+
+    func dayCell(
+        _ cell: DayTableViewCell,
+        didRequestStepperFor track: Track,
+        day: Int,
+        from sourceView: UIView
+    ) {
+        // Don't stack a second stepper (or fight a presented alert/sheet).
+        guard presentedViewController == nil else { return }
+
+        let tickController = TrackController.shared.tickController(for: track)
+        let stepper = CountStepperViewController(tickController: tickController, day: day)
+        if let popover = stepper.popoverPresentationController {
+            popover.sourceView = sourceView
+            popover.sourceRect = sourceView.bounds
+            popover.permittedArrowDirections = [.up, .down]
+            popover.delegate = self
+        }
+        present(stepper, animated: true)
+    }
+}
+
+//MARK: - UIPopoverPresentationControllerDelegate
+
+extension TrackTableViewController: UIPopoverPresentationControllerDelegate {
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle {
+        // Force a true anchored popover on iPhone (compact width) instead of
+        // letting it adapt into a full-screen sheet.
+        .none
+    }
 }
 
 //MARK: - TracksHeaderViewDelegate


### PR DESCRIPTION
## Summary
- Removes long-press gesture recognizer from tick buttons, replacing it with a popover-based count stepper
- When a user taps a multiple-mode track that already has a count ≥ 1, a popover appears with − and + buttons to adjust the count
- First tap (0 → 1) still increments directly without showing the popover, keeping the single-tap workflow fast
- Decrement button is disabled when count reaches 0
- Adds haptic feedback: selection feedback on increment, soft impact on decrement
- Fixes an issue where in-place count mutations weren't immediately republished to subscribers by re-assigning the ticks array in `TickController`

## Testing
- [ ] Tap a single-tick track → increments without showing popover
- [ ] Tap a multiple-mode track with count 0 → increments to 1, popover does not appear
- [ ] Tap a multiple-mode track with count ≥ 1 → popover appears anchored to the tapped button
- [ ] Tap + button in popover → count increments, haptic feedback triggered, button updates immediately
- [ ] Tap − button in popover → count decrements, haptic feedback triggered
- [ ] Decrement button disabled when count is 0, enabled when count > 0
- [ ] Tap outside popover or switch to another cell → popover dismisses
- [ ] Test on iPhone (compact width) → popover remains as popover, doesn't adapt to sheet
- [ ] Verify accessibility labels on − and + buttons