### PR TITLE
Add go-to-bottom header and block pre-start reversed days

### DIFF
--- a/Tickmate/Tickmate/New UI/DayTableViewCell.swift
+++ b/Tickmate/Tickmate/New UI/DayTableViewCell.swift
@@ -198,6 +198,20 @@ class DayTableViewCell: UITableViewCell {
             let button = self.button(for: track, tickController: tickController)
             self.configure(button: button, for: track, ticks: ticks)
             button.tag = index
+
+            // Mirror SwiftUI TickView.validDate: a reversed track has no
+            // meaningful state before its start date, and because an un-ticked
+            // reversed day renders as a *filled* (colored) button, those
+            // pre-start days would otherwise show as a solid block of color
+            // stretching back a year — and would be tappable, creating ticks
+            // with negative day offsets. Hide and disable them instead.
+            // `alpha`/`isUserInteractionEnabled` (rather than `isHidden`) keep
+            // the button occupying its slot so the fill-equally stack layout of
+            // the remaining buttons is unaffected.
+            let validDate = !track.reversed || day <= (tickController.todayOffset ?? 0)
+            button.alpha = validDate ? 1 : 0
+            button.isUserInteractionEnabled = validDate
+
             stackView.addArrangedSubview(button)
             button.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([

--- a/Tickmate/Tickmate/New UI/TrackTableViewController.swift
+++ b/Tickmate/Tickmate/New UI/TrackTableViewController.swift
@@ -137,6 +137,7 @@ class TrackTableViewController: UIViewController {
         tableView.scrollsToTop = todayAtTop
         previousTodayAtTop = todayAtTop
         headerView.delegate = self
+        updateGoToBottomHeader()
         syncScrollPosition()
 
         // Each page subscribes to the shared scroll offset so off-screen
@@ -288,6 +289,7 @@ class TrackTableViewController: UIViewController {
         let directionFlipped = todayAtTop != previousTodayAtTop
         previousTodayAtTop = todayAtTop
 
+        updateGoToBottomHeader()
         tableView.reloadData()
 
         if directionFlipped {
@@ -295,6 +297,48 @@ class TrackTableViewController: UIViewController {
             // new edge so the user isn't left staring at a year ago.
             scrollToToday(animated: false)
         }
+    }
+
+    //MARK: Go to Bottom
+
+    /// Mirror the SwiftUI `TicksView` "Go to bottom" button: when today rests
+    /// at the bottom (`todayAtTop` off), show a control above the oldest day
+    /// that jumps back to today. With today at the top there's nothing above
+    /// it to jump from, so no header is shown (and the date column drops its
+    /// matching spacer in step — see `ViewController.updateDateColumnSpacer`).
+    private func updateGoToBottomHeader() {
+        if todayAtTop {
+            tableView.tableHeaderView = nil
+            return
+        }
+        guard tableView.tableHeaderView == nil else { return }
+
+        let container = UIView(frame: CGRect(
+            x: 0, y: 0,
+            width: tableView.bounds.width,
+            height: ViewController.goToBottomHeaderHeight
+        ))
+        container.autoresizingMask = .flexibleWidth
+
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Go to bottom", for: .normal)
+        button.contentHorizontalAlignment = .leading
+        button.addTarget(self, action: #selector(goToBottomTapped), for: .touchUpInside)
+        container.addSubview(button)
+        NSLayoutConstraint.activate([
+            // Inset to roughly line up with the date column's leading margin.
+            button.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
+            button.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
+            button.topAnchor.constraint(equalTo: container.topAnchor),
+            button.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+
+        tableView.tableHeaderView = container
+    }
+
+    @objc private func goToBottomTapped() {
+        scrollToToday(animated: true)
     }
 
     //MARK: Day <-> Row Mapping

--- a/Tickmate/Tickmate/New UI/TrackTableViewController.swift
+++ b/Tickmate/Tickmate/New UI/TrackTableViewController.swift
@@ -327,8 +327,13 @@ class TrackTableViewController: UIViewController {
         button.addTarget(self, action: #selector(goToBottomTapped), for: .touchUpInside)
         container.addSubview(button)
         NSLayoutConstraint.activate([
-            // Inset to roughly line up with the date column's leading margin.
-            button.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
+            // The opaque date column (`ViewController.tableViewContainer`) is
+            // 100pt wide and overlaid on top of this page table, so anything
+            // left of x=100 is hidden behind it. Start the button at 120 —
+            // matching the tick-button stack leading in `DayTableViewCell` /
+            // `TracksHeaderView` — so it clears the date column and lines up
+            // with the columns of ticks below it.
+            button.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 120),
             button.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
             button.topAnchor.constraint(equalTo: container.topAnchor),
             button.bottomAnchor.constraint(equalTo: container.bottomAnchor),

--- a/Tickmate/Tickmate/New UI/ViewController.swift
+++ b/Tickmate/Tickmate/New UI/ViewController.swift
@@ -80,6 +80,12 @@ class ViewController: UIViewController {
     /// the sidebar/shadow off so the per-page header always covers them.
     static let headerHeight: CGFloat = 44
 
+    /// Height of the "Go to bottom" jump-to-today control the page tables show
+    /// above the oldest day when today rests at the bottom (`todayAtTop` off).
+    /// The date column reserves an equal-height empty spacer at the same edge
+    /// so the two synced scroll views stay aligned.
+    static let goToBottomHeaderHeight: CGFloat = 44
+
     //MARK: Lifecycle
 
     override func viewDidLoad() {
@@ -253,6 +259,27 @@ class ViewController: UIViewController {
             tableView.trailingAnchor.constraint(equalTo: tableViewContainer.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: tableViewContainer.bottomAnchor),
         ])
+
+        updateDateColumnSpacer()
+    }
+
+    /// Keep an empty top spacer in the date column that matches the page
+    /// tables' "Go to bottom" header, so each date label stays aligned with
+    /// its tick row. Present only when today rests at the bottom; cleared when
+    /// today is at the top (where the page tables show no header).
+    private func updateDateColumnSpacer() {
+        if todayAtTop {
+            tableView.tableHeaderView = nil
+        } else if tableView.tableHeaderView == nil {
+            let spacer = UIView(frame: CGRect(
+                x: 0, y: 0,
+                width: tableView.bounds.width,
+                height: Self.goToBottomHeaderHeight
+            ))
+            spacer.autoresizingMask = .flexibleWidth
+            spacer.backgroundColor = .clear
+            tableView.tableHeaderView = spacer
+        }
     }
 
     private func setUpShadow() {
@@ -371,6 +398,7 @@ class ViewController: UIViewController {
         let directionFlipped = todayAtTop != previousTodayAtTop
         previousTodayAtTop = todayAtTop
 
+        updateDateColumnSpacer()
         tableView.reloadData()
 
         if directionFlipped {


### PR DESCRIPTION
## Summary

- Add a "Go to bottom" jump-to-today button in a header above the oldest day when today rests at the bottom (`todayAtTop` off)
- Block pre-start dates for reversed tracks from showing as tappable colored buttons; these dates have no meaningful state and would otherwise appear as a solid colored block
- Keep the date column aligned by adding a matching empty spacer header that appears/disappears with the page table header
- Use `alpha` and `isUserInteractionEnabled` rather than `isHidden` to preserve button layout in the fill-equally stack

## Testing

- Verify the "Go to bottom" button appears when scrolling to the oldest day (today at bottom) and disappears when scrolling to today
- Tap "Go to bottom" and confirm it scrolls back to today
- Create or switch to a reversed track and verify pre-start dates don't render as colored/tappable buttons
- Verify date column labels stay aligned with tick rows when toggling `todayAtTop`
- Confirm the header/spacer heights match and both scroll views stay synchronized